### PR TITLE
Small example clean-up

### DIFF
--- a/examples/revisiting.py
+++ b/examples/revisiting.py
@@ -17,10 +17,7 @@ california_housing 0.486 (0.523)
 """
 import argparse
 import os.path as osp
-import random
-from typing import Dict
 
-import numpy as np
 import torch
 import torch.nn.functional as F
 from tqdm import tqdm
@@ -51,12 +48,8 @@ parser.add_argument('--epochs', type=int, default=100)
 parser.add_argument('--seed', type=int, default=0)
 args = parser.parse_args()
 
-device = (torch.device('cuda')
-          if torch.cuda.is_available() else torch.device('cpu'))
-random.seed(args.seed)
-np.random.seed(args.seed)
 torch.manual_seed(args.seed)
-torch.cuda.manual_seed_all(args.seed)
+device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
 
 # Prepare datasets
 path = osp.join(osp.dirname(osp.realpath(__file__)), '..', 'data',
@@ -121,11 +114,11 @@ else:
 optimizer = torch.optim.AdamW(model.parameters(), lr=args.lr)
 
 
-def train() -> float:
+def train(epoch: int) -> float:
     model.train()
     loss_accum = 0
 
-    for step, tf in enumerate(tqdm(train_loader)):
+    for step, tf in enumerate(tqdm(train_loader, desc=f'Epoch: {epoch}')):
         pred = model(tf)
         if is_classification:
             loss = F.cross_entropy(pred, tf.y)
@@ -139,7 +132,7 @@ def train() -> float:
 
 
 @torch.no_grad()
-def eval(loader: DataLoader) -> Dict[str, float]:
+def test(loader: DataLoader) -> float:
     model.eval()
     accum = 0
     total_count = 0
@@ -153,43 +146,39 @@ def eval(loader: DataLoader) -> Dict[str, float]:
             accum += float(
                 F.mse_loss(pred.view(-1), tf.y.view(-1), reduction='sum'))
         total_count += len(tf.y)
+
     if is_classification:
         accuracy = accum / total_count
-        return {"accuracy": accuracy}
+        return accuracy
     else:
         rmse = (accum / total_count)**0.5
-        return {"rmse": rmse}
+        return rmse
 
 
 if is_classification:
+    metric = 'Acc'
     best_val_metric = 0
     best_test_metric = 0
 else:
+    metric = 'RMSE'
     best_val_metric = float('inf')
     best_test_metric = float('inf')
 
-for epoch in range(args.epochs):
-    print(f"=====epoch {epoch}")
-    loss = train()
-    print(f'Train loss: {loss}')
-    train_metrics = eval(train_loader)
-    val_metrics = eval(val_loader)
-    test_metrics = eval(test_loader)
+for epoch in range(1, args.epochs + 1):
+    train_loss = train(epoch)
+    train_metric = test(train_loader)
+    val_metric = test(val_loader)
+    test_metric = test(test_loader)
 
-    if is_classification:
-        metric_name = "accuracy"
-        if val_metrics[metric_name] > best_val_metric:
-            best_val_metric = val_metrics[metric_name]
-            best_test_metric = test_metrics[metric_name]
-    else:
-        metric_name = "rmse"
-        if val_metrics[metric_name] < best_val_metric:
-            best_val_metric = val_metrics[metric_name]
-            best_test_metric = test_metrics[metric_name]
+    if is_classification and val_metric > best_val_metric:
+        best_val_metric = val_metric
+        best_test_metric = test_metric
+    elif val_metric < best_val_metric:
+        best_val_metric = val_metric
+        best_test_metric = test_metric
 
-    print(f'Train {metric_name}: {train_metrics[metric_name]}, '
-          f'val {metric_name}: {val_metrics[metric_name]}, '
-          f'test {metric_name}: {test_metrics[metric_name]}')
+    print(f'Train Loss: {train_loss:.4f}, Train {metric}: {train_metric:.4f}, '
+          f'Val {metric}: {val_metric:.4f}, Test {metric}: {test_metric:.4f}')
 
-print(f'Best val {metric_name}: {best_val_metric}, '
-      f'best test {metric_name}: {best_test_metric}')
+print(f'Best Val {metric}: {best_val_metric:.4f}, '
+      f'Best Test {metric}: {best_test_metric:.4f}')

--- a/examples/trompt.py
+++ b/examples/trompt.py
@@ -14,9 +14,7 @@ jannis (mathcal B4): 79.54 (80.29)
 
 import argparse
 import os.path as osp
-import random
 
-import numpy as np
 import torch
 import torch.nn.functional as F
 from torch.optim.lr_scheduler import ExponentialLR
@@ -37,13 +35,8 @@ parser.add_argument('--epochs', type=int, default=50)
 parser.add_argument('--seed', type=int, default=0)
 args = parser.parse_args()
 
-device = (torch.device('cuda')
-          if torch.cuda.is_available() else torch.device('cpu'))
-
-random.seed(args.seed)
-np.random.seed(args.seed)
 torch.manual_seed(args.seed)
-torch.cuda.manual_seed_all(args.seed)
+device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
 
 # Prepare datasets
 path = osp.join(osp.dirname(osp.realpath(__file__)), '..', 'data',
@@ -80,11 +73,11 @@ optimizer = torch.optim.Adam(model.parameters(), lr=args.lr)
 lr_scheduler = ExponentialLR(optimizer, gamma=0.95)
 
 
-def train() -> float:
+def train(epoch: int) -> float:
     model.train()
     loss_accum = 0
 
-    for step, tf in enumerate(tqdm(train_loader)):
+    for step, tf in enumerate(tqdm(train_loader, desc=f'Epoch: {epoch}')):
         # [batch_size, num_layers, num_classes]
         out = model(tf)
         num_layers = out.size(1)
@@ -102,17 +95,15 @@ def train() -> float:
 
 
 @torch.no_grad()
-def eval(loader: DataLoader) -> float:
+def test(loader: DataLoader) -> float:
     model.eval()
     accum = 0
     total_count = 0
 
     for tf in loader:
-        # [batch_size, num_layers, num_classes]
-        out = model(tf)
-        # Mean pooling across layers
-        # [batch_size, num_layers, num_classes] -> [batch_size, num_classes]
-        pred = out.mean(dim=1)
+        out = model(tf)  # [batch_size, num_layers, num_classes]
+        # Mean pooling across layers:
+        pred = out.mean(dim=1)  # [batch_size, num_classes]
         pred_class = pred.argmax(dim=-1)
         accum += float((tf.y == pred_class).sum())
         total_count += len(tf.y)
@@ -122,16 +113,15 @@ def eval(loader: DataLoader) -> float:
 
 best_val_acc = 0
 best_test_acc = 0
-for epoch in range(args.epochs):
-    print(f"=====epoch {epoch}")
-    loss = train()
-    print(f'Train loss: {loss}')
-    train_acc = eval(train_loader)
-    val_acc = eval(val_loader)
-    test_acc = eval(test_loader)
+for epoch in range(1, args.epochs + 1):
+    train_loss = train(epoch)
+    train_acc = test(train_loader)
+    val_acc = test(val_loader)
+    test_acc = test(test_loader)
     if best_val_acc < val_acc:
         best_val_acc = val_acc
         best_test_acc = test_acc
-    print(f'Train acc: {train_acc}, val acc: {val_acc}, test acc: {test_acc}')
+    print(f'Train Loss: {train_loss:.4f}, Train Acc: {train_acc:.4f}, '
+          f'Val Acc: {val_acc:.4f}, Test Acc: {test_acc:.4f}')
 
-print(f'Best val acc: {best_val_acc}, best test acc: {best_test_acc}')
+print(f'Best Val Acc: {best_val_acc:.4f}, Best Test Acc: {best_test_acc:.4f}')


### PR DESCRIPTION
* Only rely on `torch.manual_seed(...)` which is sufficient
* Move epoch logging as a description to `tqdm`
* Rename `eval` to `test` since `eval` is a reserved Python keyword
* Only show last 4-decimal points for metrics