### PR TITLE
Make model argument names consistent

### DIFF
--- a/benchmark/data_frame_benchmark.py
+++ b/benchmark/data_frame_benchmark.py
@@ -102,8 +102,8 @@ else:
     # Set up model specific search space
     if args.model_type == 'TabNet':
         model_search_space = {
-            'split_attention_channels': [64, 128, 256],
-            'split_feature_channels': [64, 128, 256],
+            'split_attn_channels': [64, 128, 256],
+            'split_feat_channels': [64, 128, 256],
             'gamma': [1., 1.2, 1.5],
             'num_layers': [4, 6, 8],
         }

--- a/examples/tabnet.py
+++ b/examples/tabnet.py
@@ -64,8 +64,8 @@ test_loader = DataLoader(test_tensor_frame, batch_size=args.batch_size)
 model = TabNet(
     out_channels=dataset.num_classes,
     num_layers=args.num_layers,
-    split_attention_channels=args.channels,
-    split_feature_channels=args.channels,
+    split_attn_channels=args.channels,
+    split_feat_channels=args.channels,
     gamma=args.gamma,
     col_stats=dataset.col_stats,
     col_names_dict=train_tensor_frame.col_names_dict,

--- a/test/nn/models/test_tabnet.py
+++ b/test/nn/models/test_tabnet.py
@@ -9,7 +9,7 @@ def test_tabnet():
     tensor_frame = dataset.tensor_frame
     out_channels = 12
     model = TabNet(out_channels=out_channels, num_layers=3,
-                   split_feature_channels=8, split_attention_channels=8,
+                   split_feat_channels=8, split_attn_channels=8,
                    gamma=1.2, col_stats=dataset.col_stats,
                    col_names_dict=tensor_frame.col_names_dict)
     model.reset_parameters()


### PR DESCRIPTION
nits found while working on #105 and #119.

- improves docstrings
- `TabNet(split_attention_channels` -> `TabNet(split_attn_channels` to be consistent with `TabTransformer(attn_dropout)`.
- `TabNet(split_feature_channel)` -> `TabNet(split_feat_channels` to be consistent with `dataset.feat_cols`.