### PR TITLE
convert to float32 by default

### DIFF
--- a/torch_frame/data/mapper.py
+++ b/torch_frame/data/mapper.py
@@ -75,7 +75,7 @@ class CategoricalTensorMapper(TensorMapper):
             left_on='data',
             right_index=True,
         )['index'].values
-        index = torch.from_numpy(index).to(device)
+        index = torch.from_numpy(index).to(dtype=torch.float32).to(device)
 
         if index.is_floating_point():
             index[index.isnan()] = -1


### PR DESCRIPTION
Otherwise I am getting 
```
    return torch.layer_norm(input, normalized_shape, weight, bias, eps, torch.backends.cudnn.enabled)
RuntimeError: expected scalar type Double but found Float
```
This happens in Trompt as well