### PR TITLE
Add `MultiNestedTensor`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
+- Added `MultiNestedTensor` ([#149](https://github.com/pyg-team/pytorch-frame/pull/149/files))
 - Added `Mercari` dataset ([#123](https://github.com/pyg-team/pytorch-frame/pull/123/files))
 - Added the model performance benchmark script ([#114](https://github.com/pyg-team/pytorch-frame/pull/114))
 - Added `DataFrameBenchmark` ([#107](https://github.com/pyg-team/pytorch-frame/pull/107))

--- a/test/data/test_multi_nested_tensor.py
+++ b/test/data/test_multi_nested_tensor.py
@@ -26,19 +26,24 @@ def test_multi_nested_tensor_basic():
     for i in range(num_rows):
         for j in range(num_cols):
             tensor = multi_nested_tensor[i, j]
+            assert isinstance(tensor, torch.Tensor)
             assert torch.allclose(tensor_mat[i][j], tensor)
 
     # Test multi_nested_tensor[i] indexing
     for i in range(num_rows):
         multi_nested_tensor_row = multi_nested_tensor[i]
+        assert multi_nested_tensor_row.num_rows == 1
+        assert multi_nested_tensor_row.num_cols == num_cols
         for j in range(num_cols):
             tensor = multi_nested_tensor_row[0, j]
+            assert isinstance(tensor, torch.Tensor)
             assert torch.allclose(tensor_mat[i][j], tensor)
 
     # Test multi_nested_tensor[List[int]] indexing
     for index in [[4], [2, 2], [4, 1, 7], [3, 7, 1, 0]]:
         multi_nested_tensor_indexed = multi_nested_tensor[index]
-
+        assert multi_nested_tensor_indexed.num_rows == len(index)
+        assert multi_nested_tensor_indexed.num_cols == num_cols
         for i, idx in enumerate(index):
             for j in range(num_cols):
                 tensor = multi_nested_tensor_indexed[i, j]

--- a/test/data/test_multi_nested_tensor.py
+++ b/test/data/test_multi_nested_tensor.py
@@ -1,5 +1,4 @@
 import random
-from collections import defaultdict
 
 import torch
 
@@ -9,19 +8,15 @@ from torch_frame.data import MultiNestedTensor
 def test_multi_nested_tensor_basic():
     num_rows = 8
     num_cols = 10
-    tensor_mat_dict = defaultdict(list)
+    tensor_mat = []
     for _ in range(num_rows):
-        tensor_list_dict = defaultdict(list)
+        tensor_list = []
         for _ in range(num_cols):
             length = random.randint(0, 10)
-            tensor_list_dict['cat'].append(
-                torch.randint(0, 100, size=(length, )))
-            tensor_list_dict['num'].append(torch.randn(size=(length, )))
-        for name, tensor_list_dict in tensor_list_dict.items():
-            tensor_mat_dict[name].append(tensor_list_dict)
+            tensor_list.append(torch.randint(0, 100, size=(length, )))
+        tensor_mat.append(tensor_list)
 
-    multi_nested_tensor = MultiNestedTensor.from_tensor_mat_dict(
-        tensor_mat_dict)
+    multi_nested_tensor = MultiNestedTensor.from_tensor_mat(tensor_mat)
     assert str(
         multi_nested_tensor) == "MultiNestedTensor(num_rows: 8, num_cols: 10)"
     assert multi_nested_tensor.num_rows == num_rows
@@ -30,19 +25,15 @@ def test_multi_nested_tensor_basic():
     # Test multi_nested_tensor[i, j] indexing
     for i in range(num_rows):
         for j in range(num_cols):
-            tensor_dict = multi_nested_tensor[i, j]
-            for name in tensor_mat_dict.keys():
-                assert torch.allclose(tensor_mat_dict[name][i][j],
-                                      tensor_dict[name])
+            tensor = multi_nested_tensor[i, j]
+            assert torch.allclose(tensor_mat[i][j], tensor)
 
     # Test multi_nested_tensor[i] indexing
     for i in range(num_rows):
         multi_nested_tensor_row = multi_nested_tensor[i]
         for j in range(num_cols):
-            tensor_dict = multi_nested_tensor_row[0, j]
-            for name in tensor_mat_dict.keys():
-                assert torch.allclose(tensor_mat_dict[name][i][j],
-                                      tensor_dict[name])
+            tensor = multi_nested_tensor_row[0, j]
+            assert torch.allclose(tensor_mat[i][j], tensor)
 
     # Test multi_nested_tensor[List[int]] indexing
     for index in [[4], [2, 2], [4, 1, 7], [3, 7, 1, 0]]:
@@ -50,7 +41,5 @@ def test_multi_nested_tensor_basic():
 
         for i, idx in enumerate(index):
             for j in range(num_cols):
-                tensor_dict = multi_nested_tensor_indexed[i, j]
-                for name in tensor_mat_dict.keys():
-                    assert torch.allclose(tensor_mat_dict[name][idx][j],
-                                          tensor_dict[name])
+                tensor = multi_nested_tensor_indexed[i, j]
+                assert torch.allclose(tensor_mat[idx][j], tensor)

--- a/test/data/test_multi_nested_tensor.py
+++ b/test/data/test_multi_nested_tensor.py
@@ -17,8 +17,8 @@ def test_multi_nested_tensor_basic():
         tensor_mat.append(tensor_list)
 
     multi_nested_tensor = MultiNestedTensor.from_tensor_mat(tensor_mat)
-    assert str(
-        multi_nested_tensor) == "MultiNestedTensor(num_rows: 8, num_cols: 10)"
+    assert str(multi_nested_tensor
+               ) == "MultiNestedTensor(num_rows=8, num_cols=10, device=cpu)"
     assert multi_nested_tensor.num_rows == num_rows
     assert multi_nested_tensor.num_cols == num_cols
 

--- a/test/data/test_multi_nested_tensor.py
+++ b/test/data/test_multi_nested_tensor.py
@@ -23,24 +23,24 @@ def test_multi_nested_tensor_basic():
     assert multi_nested_tensor.num_cols == num_cols
 
     # Test multi_nested_tensor[i, j] indexing
-    for i in range(num_rows):
+    for i in range(-num_rows, num_rows):
         for j in range(num_cols):
             tensor = multi_nested_tensor[i, j]
             assert isinstance(tensor, torch.Tensor)
             assert torch.allclose(tensor_mat[i][j], tensor)
 
     # Test multi_nested_tensor[i] indexing
-    for i in range(num_rows):
+    for i in range(-num_rows, num_rows):
         multi_nested_tensor_row = multi_nested_tensor[i]
         assert multi_nested_tensor_row.num_rows == 1
         assert multi_nested_tensor_row.num_cols == num_cols
-        for j in range(num_cols):
+        for j in range(-num_cols, num_cols):
             tensor = multi_nested_tensor_row[0, j]
             assert isinstance(tensor, torch.Tensor)
             assert torch.allclose(tensor_mat[i][j], tensor)
 
     # Test multi_nested_tensor[List[int]] indexing
-    for index in [[4], [2, 2], [4, 1, 7], [3, 7, 1, 0]]:
+    for index in [[4], [2, 2], [-4, 1, 7], [3, -7, 1, 0]]:
         multi_nested_tensor_indexed = multi_nested_tensor[index]
         assert multi_nested_tensor_indexed.num_rows == len(index)
         assert multi_nested_tensor_indexed.num_cols == num_cols

--- a/test/data/test_multi_nested_tensor.py
+++ b/test/data/test_multi_nested_tensor.py
@@ -1,0 +1,56 @@
+import random
+from collections import defaultdict
+
+import torch
+
+from torch_frame.data import MultiNestedTensor
+
+
+def test_multi_nested_tensor_basic():
+    num_rows = 8
+    num_cols = 10
+    tensor_mat_dict = defaultdict(list)
+    for _ in range(num_rows):
+        tensor_list_dict = defaultdict(list)
+        for _ in range(num_cols):
+            length = random.randint(0, 10)
+            tensor_list_dict['cat'].append(
+                torch.randint(0, 100, size=(length, )))
+            tensor_list_dict['num'].append(torch.randn(size=(length, )))
+        for name, tensor_list_dict in tensor_list_dict.items():
+            tensor_mat_dict[name].append(tensor_list_dict)
+
+    multi_nested_tensor = MultiNestedTensor.from_tensor_mat_dict(
+        tensor_mat_dict)
+    assert str(
+        multi_nested_tensor) == "MultiNestedTensor(num_rows: 8, num_cols: 10)"
+    assert multi_nested_tensor.num_rows == num_rows
+    assert multi_nested_tensor.num_cols == num_cols
+
+    # Test multi_nested_tensor[i, j] indexing
+    for i in range(num_rows):
+        for j in range(num_cols):
+            tensor_dict = multi_nested_tensor[i, j]
+            for name in tensor_mat_dict.keys():
+                assert torch.allclose(tensor_mat_dict[name][i][j],
+                                      tensor_dict[name])
+
+    # Test multi_nested_tensor[i] indexing
+    for i in range(num_rows):
+        multi_nested_tensor_row = multi_nested_tensor[i]
+        for j in range(num_cols):
+            tensor_dict = multi_nested_tensor_row[0, j]
+            for name in tensor_mat_dict.keys():
+                assert torch.allclose(tensor_mat_dict[name][i][j],
+                                      tensor_dict[name])
+
+    # Test multi_nested_tensor[List[int]] indexing
+    for index in [[4], [2, 2], [4, 1, 7], [3, 7, 1, 0]]:
+        multi_nested_tensor_indexed = multi_nested_tensor[index]
+
+        for i, idx in enumerate(index):
+            for j in range(num_cols):
+                tensor_dict = multi_nested_tensor_indexed[i, j]
+                for name in tensor_mat_dict.keys():
+                    assert torch.allclose(tensor_mat_dict[name][idx][j],
+                                          tensor_dict[name])

--- a/torch_frame/data/__init__.py
+++ b/torch_frame/data/__init__.py
@@ -1,6 +1,7 @@
 # flake8: noqa
 
 from .tensor_frame import TensorFrame
+from .multi_nested_tensor import MultiNestedTensor
 from .stats import StatType
 from .dataset import Dataset, DataFrameToTensorFrameConverter
 from .loader import DataLoader
@@ -8,6 +9,7 @@ from .download import download_url
 
 data_classes = [
     'TensorFrame',
+    'MultiNestedTensor',
     'Dataset',
 ]
 

--- a/torch_frame/data/multi_nested_tensor.py
+++ b/torch_frame/data/multi_nested_tensor.py
@@ -1,0 +1,224 @@
+import copy
+from collections import defaultdict
+from typing import Any, Callable, Dict, List, Tuple, Union
+
+import torch
+from torch import Tensor
+
+
+class MultiNestedTensor:
+    r"""A PyTorch Tensor-based data structure that stores
+    :obj:`[num_rows, num_cols, *]` , where the size of last dimension can be
+    different for different data/column. Internally, we store the object in an
+    efficient flattened format: :obj:`(value, offset)`, where the element
+    at :obj:`(i, j)` is accessed by
+    :obj:`values[offset[i*num_cols+j]:offset[i*num_cols+j+1]]`.
+    We store a dictionary of :obj:`values` so that the element at :obj:`(i, j)`
+    can be a dictionary of tensors.
+
+    Args:
+        num_rows (int): Numnber of rows.
+        num_cols (int): Number of columns.
+        values_dict (Dict[str, Tensor]): A dictionary of values Tensor.
+        offset (Tensor): The offset Tensor.
+
+
+    """
+    def __init__(self, num_rows: int, num_cols: int,
+                 values_dict: Dict[str, Tensor], offset: Tensor):
+        self.num_rows = num_rows
+        self.num_cols = num_cols
+        self.values_dict = values_dict
+        self.offset = offset
+
+    @classmethod
+    def from_tensor_mat_dict(
+        cls,
+        tensor_mat_dict: Dict[str, List[List[Tensor]]],
+    ) -> 'MultiNestedTensor':
+        r"""Construct :class:`MultiNestedTensor` object from
+        :obj:`tensor_mat_dict`.
+
+        Args:
+            tensor_mat_dict Dict[str, List[List[Tensor]]]: A dictionary of
+                matrix of PyTorch Tensors. :obj:`tensor_mat[i][j]` contains
+                1-dim PyTorch Tensor of :obj:`i`-th row and :obj:`j`-th column.
+                If there are multiple keys, we require the shape of
+                :obj:`tensor_mat_dict[key1][i][j]` and
+                :obj:`tensor_mat_dict[key2][i][j]` to be the same for every
+                :obj:`(i, j)`.
+
+        Returns:
+            MultiNestedTensor: Returned class object.
+        """
+        first_name = next(iter(tensor_mat_dict))
+        first_tensor_mat = tensor_mat_dict[first_name]
+        num_rows = len(first_tensor_mat)
+        num_cols = len(first_tensor_mat[0])
+
+        offset_list = []
+        accum_idx = 0
+        offset_list.append(accum_idx)
+        values_list_dict = defaultdict(list)
+        for row_i in range(num_rows):
+            for col_j in range(num_cols):
+                for name, tensor_mat in tensor_mat_dict.items():
+                    tensor = tensor_mat[row_i][col_j]
+                    if not isinstance(tensor, Tensor):
+                        raise RuntimeError(
+                            "The element of tensor_mat must be PyTorch Tensor")
+                    if tensor.ndim != 1:
+                        raise RuntimeError(
+                            "Each element of tensor_mat_dict must be "
+                            "1-dimensional.")
+                    if tensor.shape != first_tensor_mat[row_i][col_j].shape:
+                        raise RuntimeError(
+                            "The shape of tensor_mat_dict[key1][i][j] must be "
+                            "the same for every (i, j).")
+                    values_list_dict[name].append(tensor)
+                accum_idx += len(tensor)
+                offset_list.append(accum_idx)
+
+        values_dict = {}
+        for name, value_list in values_list_dict.items():
+            values_dict[name] = torch.cat(value_list)
+        offset = torch.tensor(offset_list, dtype=torch.long)
+
+        return cls(num_rows, num_cols, values_dict, offset)
+
+    def __repr__(self) -> str:
+        name = self.__class__.__name__
+        name += f"(num_rows: {self.num_rows}, num_cols: {self.num_cols})"
+        return name
+
+    def __copy__(self) -> 'MultiNestedTensor':
+        out = self.__class__.__new__(self.__class__)
+        for key, value in self.__dict__.items():
+            out.__dict__[key] = value
+
+        out.values_dict = copy.copy(out.values_dict)
+        out.offset = copy.copy(out.offset)
+
+        return out
+
+    def __getitem__(
+        self,
+        index: Any,
+    ) -> Union['MultiNestedTensor', Dict[str, Tensor]]:
+        if isinstance(index, Tuple):
+            # Get an element of (i, j). Returns Dict[str, Tensor]
+            assert len(index) == 2
+            if index[0] < 0 or index[0] >= self.num_rows:
+                raise IndexError(
+                    f"Index out-of-bounds. The first element of {index} needs "
+                    f"to be [0, {self.num_rows}]")
+            if index[1] < 0 or index[1] >= self.num_cols:
+                raise IndexError(
+                    f"Index out-of-bounds. The second element of {index} "
+                    f"needs to be [0, {self.num_cols}]")
+            out = {}
+            idx = index[0] * self.num_cols + index[1]
+            start_idx = self.offset[idx]
+            end_idx = self.offset[idx + 1]
+            for name, values in self.values_dict.items():
+                out[name] = values[start_idx:end_idx]
+            return out
+        elif isinstance(index, int):
+            if index < 0 or index >= self.num_rows:
+                raise IndexError(
+                    f"Index out-of-bounds. The {index} needs to be "
+                    f"[0, {self.num_rows}]")
+            # Get i-th row. Returns MultiNestedTensor
+            start_idx = index * self.num_cols
+            end_idx = (index + 1) * self.num_cols + 1
+            offset = self.offset[start_idx:end_idx]
+            values_dict = {}
+            for name, values in self.values_dict.items():
+                values_dict[name] = values[offset[0]:offset[-1]]
+            offset = offset - offset[0]
+            return MultiNestedTensor(num_rows=1, num_cols=self.num_cols,
+                                     values_dict=values_dict, offset=offset)
+        elif isinstance(index, Tensor) and index.ndim == 1:
+            return self._row_index_selet_helper(index)
+        elif isinstance(index, List):
+            return self._row_index_selet_helper(torch.LongTensor(index))
+        else:
+            raise RuntimeError("Advanced indexing not supported yet.")
+
+    def _row_index_selet_helper(self, index: Tensor) -> Tensor:
+        if index.min() < 0 or index.max() >= self.num_rows:
+            raise IndexError(f"Index out-of-bounds. The {index} needs to be "
+                             f"[0, {self.num_rows}]")
+        # Calculate values_dict
+        count = self.offset[(index + 1) *
+                            self.num_cols] - self.offset[index * self.num_cols]
+        batch, arange = batched_arange(count)
+        idx = self.offset[index * self.num_cols][batch] + arange
+        values_dict = {}
+        for name in self.values_dict.keys():
+            values_dict[name] = self.values_dict[name][idx]
+
+        # Calculate offset
+        count = torch.full(size=(len(index), ), fill_value=self.num_cols,
+                           dtype=torch.long)
+        count[-1] += 1
+        batch, arange = batched_arange(count)
+        idx = (index * self.num_cols)[batch] + arange
+        offset = self.offset[idx] - self.offset[index * self.num_cols][batch]
+        diff = self.offset[(index + 1) *
+                           self.num_cols] - self.offset[index * self.num_cols]
+        diff_cumsum = torch.cumsum(diff, dim=0)
+        diff_cumsum = torch.roll(diff_cumsum, 1)
+        diff_cumsum[0] = 0
+        offset = offset + diff_cumsum[batch]
+        return MultiNestedTensor(num_rows=len(index), num_cols=self.num_cols,
+                                 values_dict=values_dict, offset=offset)
+
+    # Device Transfer #########################################################
+
+    def to(self, *args, **kwargs):
+        return self._apply(lambda x: x.to(*args, **kwargs))
+
+    def cpu(self, *args, **kwargs):
+        return self._apply(lambda x: x.cpu(*args, **kwargs))
+
+    def cuda(self, *args, **kwargs):
+        return self._apply(lambda x: x.cuda(*args, **kwargs))
+
+    # Helper Functions ########################################################
+
+    def _apply(self, fn: Callable[[Tensor], Tensor]) -> 'MultiNestedTensor':
+        out = copy.copy(self)
+        out.values_dict = {
+            name: fn(values)
+            for name, values in out.values_dict.items()
+        }
+        out.offset = fn(out.offset)
+
+        return out
+
+
+def batched_arange(count: Tensor) -> Tuple[Tensor, Tensor]:
+    r"""Fast implementation of bached version of torch.arange.
+    It essentially does the following
+    >>> batch = torch.cat([torch.full((c,), i) for i, c in enumerate(count)])
+    >>> arange = torch.cat([torch.arange(c) for c in count])
+
+    Args:
+        counts (Tensor): The count vectors.
+
+    Returns:
+        batch (Tensor): batch[i] indicates the batch index of
+            batched_arange[i]
+        arange (Tensor): batched version of arange
+    """
+    ptr = count.new_zeros(count.numel() + 1)
+    torch.cumsum(count, dim=0, out=ptr[1:])
+
+    batch = torch.arange(count.numel(), device=count.device).repeat_interleave(
+        count, output_size=ptr[-1])  # type: ignore
+
+    arange = torch.arange(batch.numel(), device=count.device)
+    arange -= ptr[batch]
+
+    return batch, arange

--- a/torch_frame/data/multi_nested_tensor.py
+++ b/torch_frame/data/multi_nested_tensor.py
@@ -48,7 +48,7 @@ class MultiNestedTensor:
                 1-dim PyTorch Tensor of :obj:`i`-th row and :obj:`j`-th column.
 
         Returns:
-            MultiNestedTensor: Returned class object.
+            MultiNestedTensor: Returned the class object.
         """
         num_rows = len(tensor_mat)
         num_cols = len(tensor_mat[0])
@@ -63,12 +63,15 @@ class MultiNestedTensor:
                 if not isinstance(tensor, Tensor):
                     raise RuntimeError(
                         "The element of tensor_mat must be PyTorch Tensor")
+                if tensor.ndim != 1:
+                    raise RuntimeError(
+                        "tensor in tensor_mat needs to be 1-dimensional.")
                 values_list.append(tensor)
                 accum_idx += len(tensor)
                 offset_list.append(accum_idx)
 
         values = torch.cat(values_list)
-        offset = torch.tensor(offset_list, dtype=torch.long)
+        offset = torch.LongTensor(offset_list)
 
         return cls(num_rows, num_cols, values, offset)
 
@@ -190,7 +193,7 @@ class MultiNestedTensor:
 
 
 def batched_arange(count: Tensor) -> Tuple[Tensor, Tensor]:
-    r"""Fast implementation of bached version of torch.arange.
+    r"""Fast implementation of batched version of :meth:`torch.arange`.
     It essentially does the following
     >>> batch = torch.cat([torch.full((c,), i) for i, c in enumerate(count)])
     >>> arange = torch.cat([torch.arange(c) for c in count])

--- a/torch_frame/data/multi_nested_tensor.py
+++ b/torch_frame/data/multi_nested_tensor.py
@@ -17,23 +17,30 @@ class MultiNestedTensor:
         num_cols (int): Number of columns.
         values (Tensor): The values Tensor.
         offset (Tensor): The offset Tensor.
-
-
+        device (torch.device): Device to put.
     """
-    def __init__(self, num_rows: int, num_cols: int, values: Dict[str, Tensor],
-                 offset: Tensor):
+    def __init__(
+        self,
+        num_rows: int,
+        num_cols: int,
+        values: Dict[str, Tensor],
+        offset: Tensor,
+        device: torch.device = None,
+    ):
         assert offset[0] == 0
         assert offset[-1] == len(values)
         assert len(offset) == num_rows * num_cols + 1
         self.num_rows = num_rows
         self.num_cols = num_cols
-        self.values = values
-        self.offset = offset
+        self.device = device
+        self.values = values.to(self.device)
+        self.offset = offset.to(self.device)
 
     @classmethod
     def from_tensor_mat(
         cls,
         tensor_mat: List[List[Tensor]],
+        device: torch.device = None,
     ) -> 'MultiNestedTensor':
         r"""Construct :class:`MultiNestedTensor` object from
         :obj:`tensor_mat`.
@@ -42,6 +49,7 @@ class MultiNestedTensor:
             tensor_mat List[List[Tensor]]: A dictionary of
                 matrix of PyTorch Tensors. :obj:`tensor_mat[i][j]` contains
                 1-dim PyTorch Tensor of :obj:`i`-th row and :obj:`j`-th column.
+            device (torch.device): Device to put.
 
         Returns:
             MultiNestedTensor: Returned class object.
@@ -66,11 +74,12 @@ class MultiNestedTensor:
         values = torch.cat(values_list)
         offset = torch.tensor(offset_list, dtype=torch.long)
 
-        return cls(num_rows, num_cols, values, offset)
+        return cls(num_rows, num_cols, values, offset, device)
 
     def __repr__(self) -> str:
         name = self.__class__.__name__
-        name += f"(num_rows: {self.num_rows}, num_cols: {self.num_cols})"
+        name += f"(num_rows={self.num_rows}, num_cols={self.num_cols} "
+        name += f"device={self.device})"
         return name
 
     def __copy__(self) -> 'MultiNestedTensor':
@@ -119,7 +128,8 @@ class MultiNestedTensor:
         elif isinstance(index, Tensor) and index.ndim == 1:
             return self._row_index_selet_helper(index)
         elif isinstance(index, List):
-            return self._row_index_selet_helper(torch.LongTensor(index))
+            return self._row_index_selet_helper(
+                torch.LongTensor(index, device=self.device))
         else:
             raise RuntimeError("Advanced indexing not supported yet.")
 
@@ -136,7 +146,7 @@ class MultiNestedTensor:
 
         # Calculate offset
         count = torch.full(size=(len(index), ), fill_value=self.num_cols,
-                           dtype=torch.long)
+                           dtype=torch.long, device=self.device)
         count[-1] += 1
         batch, arange = batched_arange(count)
         idx = (index * self.num_cols)[batch] + arange

--- a/torch_frame/data/multi_nested_tensor.py
+++ b/torch_frame/data/multi_nested_tensor.py
@@ -9,8 +9,9 @@ class MultiNestedTensor:
     r"""A PyTorch Tensor-based data structure that stores
     :obj:`[num_rows, num_cols, *]` , where the size of last dimension can be
     different for different data/column. Internally, we store the object in an
-    efficient flattened format: :obj:`(value, offset)`, where the element
-    at :obj:`(i, j)` is accessed by
+    efficient flattened format: :obj:`(values, offset)`, where the PyTorch
+    Tensor at :obj:`(i, j)` is accessed by
+    :obj:`values[offset[i*num_cols+j]:offset[i*num_cols+j+1]]`
 
     Args:
         num_rows (int): Numnber of rows.

--- a/torch_frame/data/multi_nested_tensor.py
+++ b/torch_frame/data/multi_nested_tensor.py
@@ -76,16 +76,12 @@ class MultiNestedTensor:
         return cls(num_rows, num_cols, values, offset)
 
     def __repr__(self) -> str:
-        name = self.__class__.__name__
-        name += f"(num_rows={self.num_rows}, num_cols={self.num_cols}, "
-        name += f"device={self.values.device})"
-        return name
+        name = ' '.join([
+            f"{self.__class__.__name__}(num_rows={self.num_rows},",
+            f"num_cols={self.num_cols},", f"device={self.values.device})"
+        ])
 
-    def __copy__(self) -> 'MultiNestedTensor':
-        out = self.__class__.__new__(self.__class__)
-        for key, value in self.__dict__.items():
-            out.__dict__[key] = value
-        return out
+        return name
 
     def __getitem__(
         self,
@@ -127,14 +123,14 @@ class MultiNestedTensor:
             return MultiNestedTensor(num_rows=1, num_cols=self.num_cols,
                                      values=values, offset=offset)
         elif isinstance(index, Tensor) and index.ndim == 1:
-            return self.index_selet(index, dim=0)
+            return self.index_select(index, dim=0)
         elif isinstance(index, List):
-            return self.index_selet(
-                torch.LongTensor(index, device=self.values.device), dim=0)
+            return self.index_select(
+                torch.tensor(index, device=self.values.device), dim=0)
         else:
             raise RuntimeError("Advanced indexing not supported yet.")
 
-    def index_selet(self, index: Tensor, dim: int) -> Tensor:
+    def index_select(self, index: Tensor, dim: int) -> Tensor:
         if dim == 0:
             return self._row_index_select(index)
         else:

--- a/torch_frame/nn/models/tabnet.py
+++ b/torch_frame/nn/models/tabnet.py
@@ -145,7 +145,7 @@ class TabNet(Module):
 
         Returns:
             Union[torch.Tensor, (torch.Tensor, torch.Tensor)]: The output
-                embeddings of size [batch_size, out_channels].
+                embeddings of size :obj:`[batch_size, out_channels]`.
                 If :obj:`return_reg` is :obj:`True`, return the entropy
                 regularization as well.
         """


### PR DESCRIPTION
* Add basic functionality of `MultiNestedTensor` that supports Pytorch Tensor of shape `(num_rows, num_cols, *)`, where the last dimension can have varying sizes.

Basic usage is that
```python
# Prepare tensor_mat: List[List[Tensor]]
multi_nested_tensor = MultiNestedTensor.from_tensor_mat(tensor_mat)
# Get (i,j)-th element in Tensor
multi_nested_tensor[i, j]
# Get i-th row in `MultiNestedTensor`
multi_nested_tensor[i]
# Row index select
multi_nested_tensor[[3, 4, 5]]
```

Column index select, row slicing/arange will be supported in later PR.