### PR TITLE
Fix multicategorical stype based on review comments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
-- Added `Occurrence` stat for `multicategorical` stype ([#151](https://github.com/pyg-team/pytorch-frame/pull/151))
+- Added `MULTI_COUNT` stat for `multicategorical` stype ([#151](https://github.com/pyg-team/pytorch-frame/pull/151))
 - Added `multi_categorical` stype ([#128](https://github.com/pyg-team/pytorch-frame/pull/128))
 - Added `MultiNestedTensor` ([#149](https://github.com/pyg-team/pytorch-frame/pull/149))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
+- Added `Occurrence` stat for `multicategorical` stype ([#151](https://github.com/pyg-team/pytorch-frame/pull/151))
 - Added `multi_categorical` stype ([#128](https://github.com/pyg-team/pytorch-frame/pull/128))
 - Added `MultiNestedTensor` ([#149](https://github.com/pyg-team/pytorch-frame/pull/149))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
-- Added `MULTI_COUNT` stat for `multicategorical` stype ([#151](https://github.com/pyg-team/pytorch-frame/pull/151))
-- Added `multi_categorical` stype ([#128](https://github.com/pyg-team/pytorch-frame/pull/128))
+- Added `multi_categorical` stype ([#128](https://github.com/pyg-team/pytorch-frame/pull/128), [#151](https://github.com/pyg-team/pytorch-frame/pull/151))
 - Added `MultiNestedTensor` ([#149](https://github.com/pyg-team/pytorch-frame/pull/149))
 
 ### Changed

--- a/test/data/test_dataset.py
+++ b/test/data/test_dataset.py
@@ -104,7 +104,7 @@ def test_multicategorical_materialization():
     data = {'multicat_col': ['A|B', 'B|C|A', '', '', 'B', 'B|A', None]}
     df = pd.DataFrame(data)
     dataset = Dataset(df, {'multicat_col': stype.multicategorical},
-                      sep={'multicat_col': '|'})
+                      col_to_sep={'multicat_col': '|'})
     dataset.materialize()
     feat = dataset.tensor_frame.feat_dict[stype.multicategorical]
     assert torch.equal(feat[0, 0], torch.tensor([1, 0]))

--- a/test/data/test_dataset.py
+++ b/test/data/test_dataset.py
@@ -110,11 +110,11 @@ def test_multicategorical_materialization():
     assert torch.equal(feat[1, 0], torch.tensor([0, 3, 1], device=feat.device))
     assert torch.equal(feat[2, 0], torch.tensor([2], device=feat.device))
     assert torch.equal(feat[6, 0], torch.tensor([-1], device=feat.device))
-    assert StatType.OCCURRENCE in dataset.col_stats['a']
-    assert dataset.col_stats['a'][StatType.OCCURRENCE][0] == [
+    assert StatType.MULTI_COUNT in dataset.col_stats['a']
+    assert dataset.col_stats['a'][StatType.MULTI_COUNT][0] == [
         'B', 'A', '', 'C'
     ]
-    assert dataset.col_stats['a'][StatType.OCCURRENCE][1] == [4, 3, 2, 1]
+    assert dataset.col_stats['a'][StatType.MULTI_COUNT][1] == [4, 3, 2, 1]
 
 
 @pytest.mark.parametrize('with_nan', [True, False])

--- a/test/data/test_dataset.py
+++ b/test/data/test_dataset.py
@@ -101,17 +101,18 @@ def test_converter():
 
 
 def test_multicategorical_materialization():
-    data = {'a': ['A|B', 'B|C|A', '', '', 'B', 'B|A', None]}
+    data = {'multicat_col': ['A|B', 'B|C|A', '', '', 'B', 'B|A', None]}
     df = pd.DataFrame(data)
-    dataset = Dataset(df, {'a': stype.multicategorical}, sep={'a': '|'})
+    dataset = Dataset(df, {'multicat_col': stype.multicategorical},
+                      sep={'multicat_col': '|'})
     dataset.materialize()
     feat = dataset.tensor_frame.feat_dict[stype.multicategorical]
-    assert torch.equal(feat[0, 0], torch.tensor([1, 0], device=feat.device))
-    assert torch.equal(feat[1, 0], torch.tensor([0, 3, 1], device=feat.device))
-    assert torch.equal(feat[2, 0], torch.tensor([2], device=feat.device))
-    assert torch.equal(feat[6, 0], torch.tensor([-1], device=feat.device))
-    assert StatType.MULTI_COUNT in dataset.col_stats['a']
-    assert (dataset.col_stats['a'][StatType.MULTI_COUNT][0] == [
+    assert torch.equal(feat[0, 0], torch.tensor([1, 0]))
+    assert torch.equal(feat[1, 0], torch.tensor([0, 3, 1]))
+    assert torch.equal(feat[2, 0], torch.tensor([2]))
+    assert torch.equal(feat[6, 0], torch.tensor([-1]))
+    assert StatType.MULTI_COUNT in dataset.col_stats['multicat_col']
+    assert (dataset.col_stats['multicat_col'][StatType.MULTI_COUNT][0] == [
         'B', 'A', '', 'C'
     ])
     assert dataset.col_stats['a'][StatType.MULTI_COUNT][1] == [4, 3, 2, 1]

--- a/test/data/test_dataset.py
+++ b/test/data/test_dataset.py
@@ -89,7 +89,7 @@ def test_converter():
     dataset = FakeDataset(
         num_rows=10,
         stypes=[stype.categorical, stype.numerical,
-                stype.multi_categorical]).materialize()
+                stype.multicategorical]).materialize()
     convert_to_tensor_frame = DataFrameToTensorFrameConverter(
         col_to_stype=dataset.col_to_stype,
         col_stats=dataset.col_stats,
@@ -100,12 +100,12 @@ def test_converter():
     assert len(tf) == len(dataset)
 
 
-def test_multi_categorical_materialization():
+def test_multicategorical_materialization():
     data = {'a': ['A,B', 'B,C,A', '', 'B', None]}
     df = pd.DataFrame(data)
-    dataset = Dataset(df, {'a': stype.multi_categorical})
+    dataset = Dataset(df, {'a': stype.multicategorical})
     dataset.materialize()
-    feat = dataset.tensor_frame.feat_dict[stype.multi_categorical]
+    feat = dataset.tensor_frame.feat_dict[stype.multicategorical]
     assert torch.equal(feat[0, 0], torch.tensor([1, 0], device=feat.device))
     assert torch.equal(feat[1, 0], torch.tensor([0, 2, 1], device=feat.device))
     assert feat[2, 0].numel() == 0

--- a/test/data/test_dataset.py
+++ b/test/data/test_dataset.py
@@ -6,6 +6,7 @@ import torch
 import torch_frame
 from torch_frame import stype
 from torch_frame.data import DataFrameToTensorFrameConverter, Dataset
+from torch_frame.data.dataset import canonicalize_col_to_sep
 from torch_frame.data.stats import StatType
 from torch_frame.datasets import FakeDataset
 from torch_frame.typing import TaskType
@@ -142,3 +143,18 @@ def test_num_classes(with_nan):
     ).materialize()
     assert dataset.num_classes == num_classes
     assert dataset.task_type == task_type
+
+
+def test_canonicalize_col_to_sep():
+    col_to_sep = '|'
+    columns = ['a', 'b']
+    assert {'a': '|', 'b': '|'} == canonicalize_col_to_sep(col_to_sep, columns)
+
+    col_to_sep = {'a': '|', 'b': ','}
+    columns = ['a', 'b']
+    assert {'a': '|', 'b': ','} == canonicalize_col_to_sep(col_to_sep, columns)
+
+    col_to_sep = {'a': '|'}
+    columns = ['a', 'b']
+    with pytest.raises(ValueError, match='col_to_sep needs to specify'):
+        canonicalize_col_to_sep(col_to_sep, columns)

--- a/test/data/test_dataset.py
+++ b/test/data/test_dataset.py
@@ -111,9 +111,9 @@ def test_multicategorical_materialization():
     assert torch.equal(feat[2, 0], torch.tensor([2], device=feat.device))
     assert torch.equal(feat[6, 0], torch.tensor([-1], device=feat.device))
     assert StatType.MULTI_COUNT in dataset.col_stats['a']
-    assert dataset.col_stats['a'][StatType.MULTI_COUNT][0] == [
+    assert (dataset.col_stats['a'][StatType.MULTI_COUNT][0] == [
         'B', 'A', '', 'C'
-    ]
+    ])
     assert dataset.col_stats['a'][StatType.MULTI_COUNT][1] == [4, 3, 2, 1]
 
 

--- a/test/data/test_dataset.py
+++ b/test/data/test_dataset.py
@@ -108,14 +108,15 @@ def test_multicategorical_materialization():
     dataset.materialize()
     feat = dataset.tensor_frame.feat_dict[stype.multicategorical]
     assert torch.equal(feat[0, 0], torch.tensor([1, 0]))
-    assert torch.equal(feat[1, 0], torch.tensor([0, 3, 1]))
-    assert torch.equal(feat[2, 0], torch.tensor([2]))
+    assert torch.equal(feat[1, 0], torch.tensor([0, 2, 1]))
     assert torch.equal(feat[6, 0], torch.tensor([-1]))
     assert StatType.MULTI_COUNT in dataset.col_stats['multicat_col']
     assert (dataset.col_stats['multicat_col'][StatType.MULTI_COUNT][0] == [
-        'B', 'A', '', 'C'
+        'B', 'A', 'C'
     ])
-    assert dataset.col_stats['a'][StatType.MULTI_COUNT][1] == [4, 3, 2, 1]
+    assert dataset.col_stats['multicat_col'][StatType.MULTI_COUNT][1] == [
+        4, 3, 1
+    ]
 
 
 @pytest.mark.parametrize('with_nan', [True, False])

--- a/test/data/test_mapper.py
+++ b/test/data/test_mapper.py
@@ -41,9 +41,9 @@ def test_categorical_tensor_mapper():
 
 def test_multicategorical_tensor_mapper():
     ser = pd.Series(['A,B', 'B', '', 'C', 'B,C', None])
-    expected_values = torch.tensor([1, 0, 0, 0, -1])
-    expected_boundaries = torch.tensor([0, 2, 3, 3, 3, 4, 5])
-    mapper = MultiCategoricalTensorMapper(['B', 'A'], sep=",")
+    expected_values = torch.tensor([1, 0, 0, 2, 0, -1])
+    expected_boundaries = torch.tensor([0, 2, 3, 4, 4, 5, 6])
+    mapper = MultiCategoricalTensorMapper(['B', 'A', ''], sep=",")
 
     tensor = mapper.forward(ser)
     values = tensor.values

--- a/test/data/test_mapper.py
+++ b/test/data/test_mapper.py
@@ -41,9 +41,9 @@ def test_categorical_tensor_mapper():
 
 def test_multicategorical_tensor_mapper():
     ser = pd.Series(['A,B', 'B', '', 'C', 'B,C', None])
-    expected_values = torch.tensor([1, 0, 0, 2, 0, -1])
-    expected_boundaries = torch.tensor([0, 2, 3, 4, 4, 5, 6])
-    mapper = MultiCategoricalTensorMapper(['B', 'A', ''], sep=",")
+    expected_values = torch.tensor([1, 0, 0, 0, -1])
+    expected_boundaries = torch.tensor([0, 2, 3, 3, 3, 4, 5])
+    mapper = MultiCategoricalTensorMapper(['B', 'A'], sep=",")
 
     tensor = mapper.forward(ser)
     values = tensor.values

--- a/test/data/test_mapper.py
+++ b/test/data/test_mapper.py
@@ -49,12 +49,20 @@ def test_multicategorical_tensor_mapper():
     values = tensor.values
     offset = tensor.offset
     assert values.dtype == torch.long
-    assert torch.equal(values, expected_values)
+    assert torch.equal(
+        values[expected_boundaries[0]:expected_boundaries[1]].sort().values,
+        torch.tensor([0, 1]))
+    assert torch.equal(values[expected_boundaries[1]:],
+                       expected_values[expected_boundaries[1]:])
     assert torch.equal(offset, expected_boundaries)
 
     out = mapper.backward(tensor)
-    pd.testing.assert_series_equal(out,
-                                   pd.Series(['A,B', 'B', '', '', 'B', '']))
+    assert out.values[0] == 'A,B' or out.values[0] == 'B,A'
+    assert out.values[1] == 'B'
+    assert out.values[2] == ''
+    assert out.values[3] == ''
+    assert out.values[4] == 'B'
+    assert out.values[5] == ''
 
 
 def test_text_embedding_tensor_mapper():

--- a/test/data/test_mapper.py
+++ b/test/data/test_mapper.py
@@ -39,10 +39,10 @@ def test_categorical_tensor_mapper():
     pd.testing.assert_series_equal(out, pd.Series(['A', 'B', None, None, 'B']))
 
 
-def test_multi_categorical_tensor_mapper():
+def test_multicategorical_tensor_mapper():
     ser = pd.Series(['A,B', 'B', '', 'C', 'B,C', None])
-    expected_values = torch.tensor([1, 0, 0, -1, 0, -1, -1])
-    expected_boundaries = torch.tensor([0, 2, 3, 3, 4, 6, 7])
+    expected_values = torch.tensor([1, 0, 0, 0, -1])
+    expected_boundaries = torch.tensor([0, 2, 3, 3, 3, 4, 5])
     mapper = MultiCategoricalTensorMapper(['B', 'A'], sep=",")
 
     tensor = mapper.forward(ser)

--- a/torch_frame/__init__.py
+++ b/torch_frame/__init__.py
@@ -1,7 +1,7 @@
 from .stype import (stype, numerical, categorical, text_embedded,
-                    multi_categorical)
+                    multicategorical)
 from .data import TensorFrame
-from .typing import TaskType, DataFrame, NAStrategy
+from .typing import TaskType, DataFrame, NAStrategy, TensorData
 from torch_frame.utils import save, load, cat  # noqa
 import torch_frame.data  # noqa
 import torch_frame.datasets  # noqa
@@ -16,10 +16,11 @@ __all__ = [
     'numerical',
     'categorical',
     'text_embedded',
-    'multi_categorical',
+    'multicategorical',
     'TaskType',
     'NAStrategy',
     'TensorFrame',
+    'TensorData',
     'save',
     'load',
     'cat',

--- a/torch_frame/__init__.py
+++ b/torch_frame/__init__.py
@@ -1,7 +1,7 @@
 from .stype import (stype, numerical, categorical, text_embedded,
                     multicategorical)
 from .data import TensorFrame
-from .typing import TaskType, DataFrame, NAStrategy, TensorData
+from .typing import TaskType, DataFrame, NAStrategy
 from torch_frame.utils import save, load, cat  # noqa
 import torch_frame.data  # noqa
 import torch_frame.datasets  # noqa
@@ -20,7 +20,6 @@ __all__ = [
     'TaskType',
     'NAStrategy',
     'TensorFrame',
-    'TensorData',
     'save',
     'load',
     'cat',

--- a/torch_frame/data/dataset.py
+++ b/torch_frame/data/dataset.py
@@ -26,6 +26,7 @@ from torch_frame.typing import (
     DataFrame,
     IndexSelectType,
     TaskType,
+    TensorData,
 )
 from torch_frame.utils.split import SPLIT_TO_NUM
 
@@ -116,7 +117,7 @@ class DataFrameToTensorFrameConverter:
         elif stype == torch_frame.categorical:
             index, _ = self.col_stats[col][StatType.COUNT]
             return CategoricalTensorMapper(index)
-        elif stype == torch_frame.multi_categorical:
+        elif stype == torch_frame.multicategorical:
             index, _ = self.col_stats[col][StatType.COUNT]
             return MultiCategoricalTensorMapper(index, sep=self.sep)
         elif stype == torch_frame.text_embedded:
@@ -136,9 +137,7 @@ class DataFrameToTensorFrameConverter:
         r"""Convert a given :obj:`DataFrame` object into :class:`TensorFrame`
         object."""
 
-        xs_dict: Dict[torch_frame.stype,
-                      List[Union[Tensor,
-                                 MultiNestedTensor]]] = defaultdict(list)
+        xs_dict: Dict[torch_frame.stype, List[TensorData]] = defaultdict(list)
 
         for stype, col_names in self.col_names_dict.items():
             for col in col_names:
@@ -210,7 +209,7 @@ class Dataset(ABC):
                              f"but missing in the data frame")
 
         if (target_col is not None and self.col_to_stype[target_col]
-                == torch_frame.multi_categorical):
+                == torch_frame.multicategorical):
             raise ValueError(
                 'Multilabel classification task is not yet supported.')
 
@@ -335,7 +334,7 @@ class Dataset(ABC):
 
         # 1. Fill column statistics:
         for col, stype in self.col_to_stype.items():
-            if stype == torch_frame.multi_categorical:
+            if stype == torch_frame.multicategorical:
                 ser = self.df[col].apply(
                     lambda x: [cat.strip() for cat in x.split(self.sep)]
                     if x is not None and x != '' else [])

--- a/torch_frame/data/dataset.py
+++ b/torch_frame/data/dataset.py
@@ -1,7 +1,6 @@
 import copy
 import functools
 import os.path as osp
-import warnings
 from abc import ABC
 from collections import defaultdict
 from typing import Any, Dict, List, Optional, Tuple, Union
@@ -67,10 +66,10 @@ class DataFrameToTensorFrameConverter:
             column name into stats. Available as :obj:`dataset.col_stats`.
         target_col (str, optional): The column used as target.
             (default: :obj:`None`)
-        col_to_sep (Union[str, Dict[str, str]], optional): A dictionary that
+        col_to_sep (Union[str, Dict[str, str]]): A dictionary that
             maps each multi_categorical column to its delimiter or a string
             indicating the delimiter for all multi_categorical columns. If not
-            specified, then :obj:`,` will be used. (default: :obj:`None`)
+            specified, then :obj:`,` will be used. (default: :obj:`,`)
         text_embedder_cfg
             (:class:`torch_frame.config.TextEmbedderConfig`, optional):
             A text embedder config specifying :obj:`text_embedder` that
@@ -83,19 +82,13 @@ class DataFrameToTensorFrameConverter:
         col_to_stype: Dict[str, torch_frame.stype],
         col_stats: Dict[str, Dict[StatType, Any]],
         target_col: Optional[str] = None,
-        col_to_sep: Optional[Union[str, Dict[str, str]]] = None,
+        col_to_sep: Union[str, Dict[str, str]] = ',',
         text_embedder_cfg: Optional[TextEmbedderConfig] = None,
     ):
-        col_to_sep = col_to_sep or ","
         if isinstance(col_to_sep, Dict):
             for col in col_to_stype:
                 if (col_to_stype[col] == torch_frame.multicategorical
                         and col not in col_to_sep):
-                    warnings.warn(
-                        "The delimiter is not specified for multicategorical "
-                        f"column: {col}. ',' will be set as default delimiter."
-                    )
-
                     col_to_sep[col] = ','
         self.col_to_stype = col_to_stype
         self.col_stats = col_stats
@@ -186,10 +179,10 @@ class Dataset(ABC):
         split_col (str, optional): The column that stores the pre-defined split
             information. The column should only contain :obj:`0`, :obj:`1`, or
             :obj:`2`. (default: :obj:`None`).
-        col_to_sep (Union[str, Dict[str, str]], optional): A dictionary that
+        col_to_sep (Union[str, Dict[str, str]]): A dictionary that
             maps each multi_categorical column to its delimiter or a string
             indicating the delimiter for all multi_categorical columns. If not
-            specified, then :obj:`,` will be used. (default: :obj:`None`)
+            specified, then :obj:`,` will be used. (default: :obj:`,`)
         text_embedder_cfg (TextEmbedderConfig, optional): A text embedder
             configuration that specifies the text embedder to map text columns
             into :pytorch:`PyTorch` embeddings. (default: :obj:`None`)
@@ -233,16 +226,10 @@ class Dataset(ABC):
             raise ValueError(
                 'Multilabel classification task is not yet supported.')
 
-        col_to_sep = col_to_sep or ","
         if isinstance(col_to_sep, Dict):
             for col in col_to_stype:
                 if (col_to_stype[col] == torch_frame.multicategorical
                         and col not in col_to_sep):
-                    warnings.warn(
-                        "The delimiter is not specified for multicategorical "
-                        f"column: {col}. ',' will be set as default delimiter."
-                    )
-
                     col_to_sep[col] = ','
 
         self.text_embedder_cfg = text_embedder_cfg

--- a/torch_frame/data/dataset.py
+++ b/torch_frame/data/dataset.py
@@ -1,7 +1,7 @@
 import copy
 import functools
-import logging
 import os.path as osp
+import warnings
 from abc import ABC
 from collections import defaultdict
 from typing import Any, Dict, List, Optional, Tuple, Union
@@ -119,7 +119,7 @@ class DataFrameToTensorFrameConverter:
             index, _ = self.col_stats[col][StatType.COUNT]
             return CategoricalTensorMapper(index)
         elif stype == torch_frame.multicategorical:
-            index, _ = self.col_stats[col][StatType.OCCURRENCE]
+            index, _ = self.col_stats[col][StatType.MULTI_COUNT]
             if col not in self.sep:
                 warnings.warn(
                     "The separator is not specified for multicategorical"

--- a/torch_frame/data/dataset.py
+++ b/torch_frame/data/dataset.py
@@ -121,7 +121,7 @@ class DataFrameToTensorFrameConverter:
         elif stype == torch_frame.multicategorical:
             index, _ = self.col_stats[col][StatType.OCCURRENCE]
             if col not in self.sep:
-                logging.warning(
+                warnings.warn(
                     "The separator is not specified for multicategorical"
                     " column: {col}. ',' will be set as default separator.")
                 self.sep[col] = ','

--- a/torch_frame/data/dataset.py
+++ b/torch_frame/data/dataset.py
@@ -80,7 +80,7 @@ class DataFrameToTensorFrameConverter:
         col_to_stype: Dict[str, torch_frame.stype],
         col_stats: Dict[str, Dict[StatType, Any]],
         target_col: Optional[str] = None,
-        sep: Dict[str, str] = {},
+        sep: Optional[Dict[str, str]] = None,
         text_embedder_cfg: Optional[TextEmbedderConfig] = None,
     ):
         self.col_to_stype = col_to_stype

--- a/torch_frame/data/dataset.py
+++ b/torch_frame/data/dataset.py
@@ -67,7 +67,8 @@ def canonicalize_col_to_sep(col_to_sep: Union[str, Dict[str, str]],
             use a separator specified for each column. (default: :obj:`,`)
 
     Returns:
-        Dict[str, str]: Canonical :obj:`col_to_sep` in a dictionary format.
+        Dict[str, str]: :obj:`col_to_sep` in a dictionary format, mapping
+            multi-categorical columns into their specified separators.
     """
     if isinstance(col_to_sep, str):
         sep = col_to_sep
@@ -79,7 +80,7 @@ def canonicalize_col_to_sep(col_to_sep: Union[str, Dict[str, str]],
         if len(missing_cols) > 0:
             raise ValueError(
                 f"col_to_sep needs to specify separators for all "
-                f"multi-categorical columns, but the separator for the "
+                f"multi-categorical columns, but the separators for the "
                 f"following columns are missing: {missing_cols}.")
     return col_to_sep
 

--- a/torch_frame/data/dataset.py
+++ b/torch_frame/data/dataset.py
@@ -398,7 +398,7 @@ class Dataset(ABC):
             col_to_stype=self.col_to_stype,
             col_stats=self._col_stats,
             target_col=self.target_col,
-            sep=self.sep,
+            col_to_sep=self.col_to_sep,
             text_embedder_cfg=self.text_embedder_cfg,
         )
 

--- a/torch_frame/data/dataset.py
+++ b/torch_frame/data/dataset.py
@@ -82,7 +82,7 @@ def canonicalize_col_to_sep(col_to_sep: Union[str, Dict[str, str]],
             raise ValueError(
                 f"col_to_sep needs to specify separators for all "
                 f"multi-categorical columns, but the separators for the "
-                f"following columns are missing: {missing_cols}.")
+                f"following columns are missing: {list(missing_cols)}.")
     return col_to_sep
 
 

--- a/torch_frame/data/dataset.py
+++ b/torch_frame/data/dataset.py
@@ -65,6 +65,7 @@ def canonicalize_col_to_sep(col_to_sep: Union[str, Dict[str, str]],
             columns. If a string is specified, then the same separator will be
             used throughout all the multi-categorical columns. Otherwise, we
             use a separator specified for each column. (default: :obj:`,`)
+        columns (List[str]): A list of multi-categorical columns.
 
     Returns:
         Dict[str, str]: :obj:`col_to_sep` in a dictionary format, mapping

--- a/torch_frame/data/dataset.py
+++ b/torch_frame/data/dataset.py
@@ -368,7 +368,8 @@ class Dataset(ABC):
         for col, stype in self.col_to_stype.items():
             ser = self.df[col]
             self._col_stats[col] = compute_col_stats(
-                ser, stype, sep=self.sep.get(col, None))
+                ser, stype, sep=self.col_to_sep[col]
+                if isinstance(col, Dict) else self.col_to_sep)
             # For a target column, sort categories lexicographically such that
             # we do not accidentally swap labels in binary classification
             # tasks.

--- a/torch_frame/data/dataset.py
+++ b/torch_frame/data/dataset.py
@@ -342,7 +342,7 @@ class Dataset(ABC):
         for col, stype in self.col_to_stype.items():
             ser = self.df[col]
             if stype == torch_frame.multicategorical and col not in self.sep:
-                logging.warning(
+                warnings.warn(
                     "The separator is not specified for multicategorical"
                     " column: {col}. ',' will be set as default separator.")
                 self.sep[col] = ','

--- a/torch_frame/data/dataset.py
+++ b/torch_frame/data/dataset.py
@@ -63,8 +63,9 @@ def canonicalize_col_to_sep(col_to_sep: Union[str, Dict[str, str]],
         col_to_sep (Union[str, Dict[str, str]]): A dictionary or a string
             specifying the separator/delimiter for the multi-categorical
             columns. If a string is specified, then the same separator will be
-            used throughout all the multi-categorical columns. Otherwise, we
-            use a separator specified for each column. (default: :obj:`,`)
+            used throughout all the multi-categorical columns. If a dictionary
+            is given, we use a separator specified for each column.
+            (default: :obj:`,`)
         columns (List[str]): A list of multi-categorical columns.
 
     Returns:
@@ -100,8 +101,9 @@ class DataFrameToTensorFrameConverter:
         col_to_sep (Union[str, Dict[str, str]]): A dictionary or a string
             specifying the separator/delimiter for the multi-categorical
             columns. If a string is specified, then the same separator will be
-            used throughout all the multi-categorical columns. Otherwise, we
-            use a separator specified for each column. (default: :obj:`,`)
+            used throughout all the multi-categorical columns. If a dictionary
+            is given, we use a separator specified for each column.
+            (default: :obj:`,`)
         text_embedder_cfg
             (:class:`torch_frame.config.TextEmbedderConfig`, optional):
             A text embedder config specifying :obj:`text_embedder` that
@@ -211,8 +213,9 @@ class Dataset(ABC):
         col_to_sep (Union[str, Dict[str, str]]): A dictionary or a string
             specifying the separator/delimiter for the multi-categorical
             columns. If a string is specified, then the same separator will be
-            used throughout all the multi-categorical columns. Otherwise, we
-            use a separator specified for each column. (default: :obj:`,`)
+            used throughout all the multi-categorical columns. If a dictionary
+            is given, we use a separator specified for each column.
+            (default: :obj:`,`)
         text_embedder_cfg (TextEmbedderConfig, optional): A text embedder
             configuration that specifies the text embedder to map text columns
             into :pytorch:`PyTorch` embeddings. (default: :obj:`None`)

--- a/torch_frame/data/dataset.py
+++ b/torch_frame/data/dataset.py
@@ -128,8 +128,8 @@ class DataFrameToTensorFrameConverter:
         elif stype == torch_frame.multicategorical:
             index, _ = self.col_stats[col][StatType.MULTI_COUNT]
             return MultiCategoricalTensorMapper(
-                index, sep=self.col_to_sep[col] if isinstance(
-                    self.col_to_sep, Dict) else self.col_to_sep)
+                index, sep=self.col_to_sep
+                if isinstance(self.col_to_sep, str) else self.col_to_sep[col])
         elif stype == torch_frame.text_embedded:
             return TextEmbeddingTensorMapper(
                 self.text_embedder_cfg.text_embedder,
@@ -193,7 +193,7 @@ class Dataset(ABC):
         col_to_stype: Dict[str, torch_frame.stype],
         target_col: Optional[str] = None,
         split_col: Optional[str] = None,
-        col_to_sep: Optional[Union[str, Dict[str, str]]] = None,
+        col_to_sep: Union[str, Dict[str, str]] = ",",
         text_embedder_cfg: Optional[TextEmbedderConfig] = None,
     ):
         self.df = df
@@ -355,8 +355,8 @@ class Dataset(ABC):
         for col, stype in self.col_to_stype.items():
             ser = self.df[col]
             self._col_stats[col] = compute_col_stats(
-                ser, stype, sep=self.col_to_sep[col]
-                if isinstance(col, Dict) else self.col_to_sep)
+                ser, stype, sep=self.col_to_sep if isinstance(
+                    self.col_to_sep, str) else self.col_to_sep[col])
             # For a target column, sort categories lexicographically such that
             # we do not accidentally swap labels in binary classification
             # tasks.

--- a/torch_frame/data/dataset.py
+++ b/torch_frame/data/dataset.py
@@ -120,10 +120,12 @@ class DataFrameToTensorFrameConverter:
             return CategoricalTensorMapper(index)
         elif stype == torch_frame.multicategorical:
             index, _ = self.col_stats[col][StatType.MULTI_COUNT]
-            if col not in self.sep:
+            if self.sep is None or col not in self.sep:
                 warnings.warn(
                     "The separator is not specified for multicategorical"
                     " column: {col}. ',' will be set as default separator.")
+                if self.sep is None:
+                    self.sep = {}
                 self.sep[col] = ','
             return MultiCategoricalTensorMapper(index, sep=self.sep[col])
         elif stype == torch_frame.text_embedded:
@@ -341,10 +343,13 @@ class Dataset(ABC):
         # 1. Fill column statistics:
         for col, stype in self.col_to_stype.items():
             ser = self.df[col]
-            if stype == torch_frame.multicategorical and col not in self.sep:
+            if stype == torch_frame.multicategorical and (self.sep is None or
+                                                          col not in self.sep):
                 warnings.warn(
                     "The separator is not specified for multicategorical"
                     " column: {col}. ',' will be set as default separator.")
+                if self.sep is None:
+                    self.sep = {}
                 self.sep[col] = ','
             self._col_stats[col] = compute_col_stats(
                 ser, stype, sep=self.sep.get(col, None))

--- a/torch_frame/data/mapper.py
+++ b/torch_frame/data/mapper.py
@@ -92,7 +92,8 @@ class CategoricalTensorMapper(TensorMapper):
 class MultiCategoricalTensorMapper(TensorMapper):
     r"""Maps any multi-categorical series into an index representation, with
     :obj:`-1` denoting missing values (NaN) and no value denoting not belonging
-    to any categories.
+    to any categories. If the cell contains unseen categories, it will be
+    ignored.
 
     Args:
         categories (List[Any]): A list of possible categories in the

--- a/torch_frame/data/mapper.py
+++ b/torch_frame/data/mapper.py
@@ -116,11 +116,11 @@ class MultiCategoricalTensorMapper(TensorMapper):
 
     def _split_by_sep(self, row: str):
         if row is None:
-            return [-1]
+            return set([-1])
         elif row == '':
-            return []
+            return set()
         else:
-            return row.split(self.sep)
+            return set(row.split(self.sep))
 
     def forward(
         self,

--- a/torch_frame/data/mapper.py
+++ b/torch_frame/data/mapper.py
@@ -97,7 +97,7 @@ class MultiCategoricalTensorMapper(TensorMapper):
 
     Args:
         categories (List[Any]): A list of possible categories in the
-        multi-categorical column sorted by occurence.
+        multi-categorical column sorted by occurrence.
         sep (str): The delimiter for the categories in each cell.
         (default: :obj:`,`)
     """

--- a/torch_frame/data/mapper.py
+++ b/torch_frame/data/mapper.py
@@ -147,8 +147,8 @@ class MultiCategoricalTensorMapper(TensorMapper):
         offset = pd.concat((pd.Series([0]), offset))
         offset = torch.tensor(offset.values, device=device)
         offset = torch.cumsum(offset, dim=0)
-        return MultiNestedTensor(num_rows=len(ser), num_cols=1, values=values,
-                                 offset=offset)
+        return MultiNestedTensor(num_rows=len(original_index), num_cols=1,
+                                 values=values, offset=offset)
 
     def backward(self, tensor: MultiNestedTensor) -> pd.Series:
         values = tensor.values

--- a/torch_frame/data/mapper.py
+++ b/torch_frame/data/mapper.py
@@ -97,7 +97,7 @@ class MultiCategoricalTensorMapper(TensorMapper):
 
     Args:
         categories (List[Any]): A list of possible categories in the
-        multi-categorical column sorted by occurrence.
+        multi-categorical column sorted by counts.
         sep (str): The delimiter for the categories in each cell.
         (default: :obj:`,`)
     """
@@ -118,6 +118,8 @@ class MultiCategoricalTensorMapper(TensorMapper):
     def _split_by_sep(self, row: str):
         if row is None:
             return [-1]
+        elif row == '':
+            return []
         else:
             return row.split(self.sep)
 
@@ -141,11 +143,11 @@ class MultiCategoricalTensorMapper(TensorMapper):
             right_index=True,
         ).dropna()
         ser['index'] = ser['index'].astype('int64')
-        values = torch.tensor(ser['index'].values, device=device)
+        values = torch.from_numpy(ser['index'].values)
         offset = ser.index.value_counts()
         offset = offset.reindex(original_index, fill_value=0)
         offset = pd.concat((pd.Series([0]), offset))
-        offset = torch.tensor(offset.values, device=device)
+        offset = torch.from_numpy(offset.values)
         offset = torch.cumsum(offset, dim=0)
         return MultiNestedTensor(num_rows=len(original_index), num_cols=1,
                                  values=values, offset=offset)

--- a/torch_frame/data/mapper.py
+++ b/torch_frame/data/mapper.py
@@ -92,8 +92,7 @@ class CategoricalTensorMapper(TensorMapper):
 class MultiCategoricalTensorMapper(TensorMapper):
     r"""Maps any multi-categorical series into an index representation, with
     :obj:`-1` denoting missing values (NaN) and no value denoting not belonging
-    to any categories. If the cell contains unseen categories, it will be
-    ignored.
+    to any categories. Unseen categories will be ignored.
 
     Args:
         categories (List[Any]): A list of possible categories in the

--- a/torch_frame/data/stats.py
+++ b/torch_frame/data/stats.py
@@ -64,6 +64,7 @@ class StatType(Enum):
             return count.index.tolist(), count.values.tolist()
         elif self == StatType.MULTI_COUNT:
             assert sep is not None
+            print("sep is ", sep)
             ser = ser.apply(
                 lambda x: set([cat.strip() for cat in x.split(sep)])
                 if (x is not None and x != '') else set())

--- a/torch_frame/data/stats.py
+++ b/torch_frame/data/stats.py
@@ -76,7 +76,7 @@ class StatType(Enum):
 def compute_col_stats(
     ser: Series,
     stype: torch_frame.stype,
-    sep: Optional[str],
+    sep: Optional[str] = None,
 ) -> Dict[StatType, Any]:
 
     if stype == torch_frame.numerical:

--- a/torch_frame/data/stats.py
+++ b/torch_frame/data/stats.py
@@ -39,7 +39,7 @@ class StatType(Enum):
             ]
         elif stype == torch_frame.text_embedded:
             return []
-        elif stype == torch_frame.multi_categorical:
+        elif stype == torch_frame.multicategorical:
             return [
                 StatType.COUNT,
             ]

--- a/torch_frame/data/stats.py
+++ b/torch_frame/data/stats.py
@@ -26,7 +26,7 @@ class StatType(Enum):
     COUNT = 'COUNT'
 
     # Multicategorical:
-    OCCURRENCE = 'OCCURRENCE'
+    MULTI_COUNT = 'MULTI_COUNT'
 
     @staticmethod
     def stats_for_stype(stype: torch_frame.stype) -> List['StatType']:
@@ -44,7 +44,7 @@ class StatType(Enum):
             return []
         elif stype == torch_frame.multicategorical:
             return [
-                StatType.OCCURRENCE,
+                StatType.MULTI_COUNT,
             ]
 
         raise NotImplementedError(f"Invalid semantic type '{stype.value}'")
@@ -62,7 +62,7 @@ class StatType(Enum):
         elif self == StatType.COUNT:
             count = ser.value_counts(ascending=False)
             return count.index.tolist(), count.values.tolist()
-        elif self == StatType.OCCURRENCE:
+        elif self == StatType.MULTI_COUNT:
             assert sep is not None
             ser = ser.apply(
                 lambda x: set([cat.strip() for cat in x.split(sep)])

--- a/torch_frame/data/stats.py
+++ b/torch_frame/data/stats.py
@@ -49,7 +49,7 @@ class StatType(Enum):
 
         raise NotImplementedError(f"Invalid semantic type '{stype.value}'")
 
-    def compute(self, ser: Series, sep: Optional[str]) -> Any:
+    def compute(self, ser: Series, sep: Optional[str] = None) -> Any:
         if self == StatType.MEAN:
             return np.mean(ser.values).item()
 

--- a/torch_frame/data/stats.py
+++ b/torch_frame/data/stats.py
@@ -66,7 +66,7 @@ class StatType(Enum):
             assert sep is not None
             ser = ser.apply(
                 lambda x: set([cat.strip() for cat in x.split(sep)])
-                if x is not None else set())
+                if (x is not None and x != '') else set())
             ser = ser.explode().dropna()
             count = ser.value_counts(ascending=False)
             return count.index.tolist(), count.values.tolist()

--- a/torch_frame/datasets/fake.py
+++ b/torch_frame/datasets/fake.py
@@ -68,7 +68,7 @@ class FakeDataset(torch_frame.data.Dataset):
                     arr[1::2] = np.nan
                 df_dict[col_name] = arr
                 col_to_stype[col_name] = stype.categorical
-        if stype.multi_categorical in stypes:
+        if stype.multicategorical in stypes:
             # TODO: Currently having multiple multi-categorical columns
             # is not supported. Please add test case for multiple
             # multi-categorical columns when it's added.
@@ -79,7 +79,7 @@ class FakeDataset(torch_frame.data.Dataset):
                 if with_nan:
                     arr[1::2] = None
                 df_dict[col_name] = list(arr)
-                col_to_stype[col_name] = stype.multi_categorical
+                col_to_stype[col_name] = stype.multicategorical
         if stype.text_embedded in stypes:
             for col_name in ['text_1', 'text_2']:
                 arr = ['Hello world!'] * num_rows

--- a/torch_frame/stype.py
+++ b/torch_frame/stype.py
@@ -23,7 +23,7 @@ class stype(Enum):
     numerical = 'numerical'
     categorical = 'categorical'
     text_embedded = 'text_embedded'
-    multi_categorical = 'multi_categorical'
+    multicategorical = 'multicategorical'
 
     @property
     def is_text_stype(self) -> bool:
@@ -34,10 +34,10 @@ class stype(Enum):
         r""" This property indicates if the data of an stype is stored in
         :class:`torch_frame.data.MultiNestedTensor`.
         """
-        return self in [stype.multi_categorical]
+        return self in [stype.multicategorical]
 
 
 numerical = stype('numerical')
 categorical = stype('categorical')
 text_embedded = stype('text_embedded')
-multi_categorical = stype('multi_categorical')
+multicategorical = stype('multicategorical')

--- a/torch_frame/typing.py
+++ b/torch_frame/typing.py
@@ -4,6 +4,8 @@ from typing import List, Union
 import pandas as pd
 from torch import Tensor
 
+from torch_frame.data.multi_nested_tensor import MultiNestedTensor
+
 
 class TaskType(Enum):
     r"""The type of the task.
@@ -57,3 +59,4 @@ DataFrame = pd.DataFrame
 
 IndexSelectType = Union[int, List[int], range, slice, Tensor]
 ColumnSelectType = Union[str, List[str]]
+TensorData = Union[Tensor, MultiNestedTensor]


### PR DESCRIPTION
Based on the comments in #128 , the following changes are made in this pr:
1. Added an `MULTI_COUNT` stat type for `multicategorical` stype.
2. Modified the name of `multi_categorical` stype to `multicategorical` stype.
3. Modified the mappings. Now missing values will be mapped to `-1`, no value is considered as a category and unseen values are all ignored.