### PR TITLE
convert series type to string before putting it into text embedder

### DIFF
--- a/test/data/test_mapper.py
+++ b/test/data/test_mapper.py
@@ -61,11 +61,11 @@ def test_text_embedding_tensor_mapper():
     out_channels = 10
     num_sentences = 20
     ser = pd.Series(["Hello world!"] * (num_sentences // 2) +
-                    ["I love torch-frame"] * (num_sentences // 2))
+                    ["I love torch-frame"] * (num_sentences // 2) + [0.1])
     mapper = TextEmbeddingTensorMapper(HashTextEmbedder(out_channels),
                                        batch_size=8)
     emb = mapper.forward(ser)
-    assert emb.shape == (num_sentences, out_channels)
+    assert emb.shape == (num_sentences + 1, out_channels)
     mapper.batch_size = None
     emb2 = mapper.forward(ser)
     assert torch.allclose(emb, emb2)

--- a/torch_frame/data/mapper.py
+++ b/torch_frame/data/mapper.py
@@ -180,6 +180,7 @@ class TextEmbeddingTensorMapper(TensorMapper):
         *,
         device: Optional[torch.device] = None,
     ) -> Tensor:
+        ser = ser.astype(str)
         ser_list = ser.tolist()
         if self.batch_size is None:
             emb = self.text_embedder(ser_list)


### PR DESCRIPTION
I got the following error when processing a customer's data
```
  File "/home/ubuntu/git/pytorch-frame/examples/example.py", line 93, in <module>
    dataset.materialize()
  File "/home/ubuntu/git/pytorch-frame/torch_frame/data/dataset.py", line 332, in materialize
    self._tensor_frame = self._to_tensor_frame_converter(self.df, device)
  File "/home/ubuntu/git/pytorch-frame/torch_frame/data/dataset.py", line 135, in __call__
    out = self._get_mapper(col).forward(df[col], device=device)
  File "/home/ubuntu/git/pytorch-frame/torch_frame/data/mapper.py", line 130, in forward
    emb = self.text_embedder(ser_list[i:i + self.batch_size])
  File "/home/ubuntu/git/pytorch-frame/examples/example.py", line 83, in __call__
    embeddings = self.model.encode(sentences, convert_to_numpy=False,
  File "/home/ubuntu/git/kumo/venv/lib/python3.10/site-packages/sentence_transformers/SentenceTransformer.py", line 161, in encode
    features = self.tokenize(sentences_batch)
  File "/home/ubuntu/git/kumo/venv/lib/python3.10/site-packages/sentence_transformers/SentenceTransformer.py", line 319, in tokenize
    return self._first_module().tokenize(texts)
  File "/home/ubuntu/git/kumo/venv/lib/python3.10/site-packages/sentence_transformers/models/Transformer.py", line 102, in tokenize
    batch1.append(text_tuple[0])
TypeError: 'float' object is not subscriptable
```

Related issue: https://github.com/MaartenGr/BERTopic/issues/427