### PR TITLE
Disallow `__setitem__` for `MultiNestedTensor`

### DIFF
--- a/test/data/test_multi_nested_tensor.py
+++ b/test/data/test_multi_nested_tensor.py
@@ -164,6 +164,10 @@ def test_multi_nested_tensor_basic():
             for j in range(multi_nested_tensor.size(1))
         ], dim=1),
 
+    # Testing set item
+    with pytest.raises(RuntimeError, match="read-only"):
+        multi_nested_tensor[0, 0] = torch.zeros(3)
+
     # Testing clone
     cloned_multi_nested_tensor = multi_nested_tensor.clone()
     multi_nested_tensor.values[0] = max_value + 1.0

--- a/torch_frame/data/multi_nested_tensor.py
+++ b/torch_frame/data/multi_nested_tensor.py
@@ -116,6 +116,11 @@ class MultiNestedTensor:
 
         return cls(num_rows, num_cols, values, offset)
 
+    def __setitem__(self, index: Any, values: Any):
+        raise RuntimeError(
+            "MultiNestedTensor object does not support setting values. "
+            "It should be used for read-only. ")
+
     def __getitem__(
         self,
         index: Any,


### PR DESCRIPTION
as `MultiNestedTensor` should be used as read-only. Also setting values will be slow and not preferred.