### PR TITLE
Fix stats computation for `sequence_numerical` with `NaN` elements

### DIFF
--- a/test/data/test_stats.py
+++ b/test/data/test_stats.py
@@ -46,6 +46,30 @@ def test_compute_col_stats_all_sequence_numerical():
     }
 
 
+def test_compute_col_stats_all_sequence_numerical_with_nan_inf():
+    ser = pd.Series([[1, 2, 3, np.nan], [4, 5, 6]])
+    expected_col_stats = {
+        StatType.MEAN: 3.5,
+        StatType.STD: 1.707825127659933,
+        StatType.QUANTILES: [1.0, 2.25, 3.5, 4.75, 6.0],
+    }
+    stype = sequence_numerical
+    assert compute_col_stats(ser, stype) == expected_col_stats
+    ser = pd.Series([[1, 2, 3, np.inf], [4, 5, 6]])
+    assert compute_col_stats(ser, stype) == expected_col_stats
+
+
+def test_compute_col_stats_all_sequence_numerical_with_all_nan():
+    ser = pd.Series([[np.nan, np.nan, np.nan, np.inf],
+                     [np.nan, np.nan, np.nan]])
+    stype = sequence_numerical
+    assert compute_col_stats(ser, stype) == {
+        StatType.MEAN: np.nan,
+        StatType.STD: np.nan,
+        StatType.QUANTILES: [np.nan, np.nan, np.nan, np.nan, np.nan],
+    }
+
+
 def test_compute_col_stats_numerical_with_inf():
     ser = pd.Series([1, 2, 3, np.inf, -np.inf])
     stype = numerical

--- a/torch_frame/data/stats.py
+++ b/torch_frame/data/stats.py
@@ -49,15 +49,27 @@ class StatType(Enum):
     def compute(self, ser: Series, sep: Optional[str] = None) -> Any:
         if self == StatType.MEAN:
             flattened = np.hstack(np.hstack(ser.values))
-            return np.mean(flattened).item()
+            finite_mask = np.isfinite(flattened)
+            if not finite_mask.any():
+                return np.nan
+            return np.mean(flattened[finite_mask])
 
         elif self == StatType.STD:
             flattened = np.hstack(np.hstack(ser.values))
-            return np.std(flattened).item()
+            finite_mask = np.isfinite(flattened)
+            if not finite_mask.any():
+                return np.nan
+            return np.std(flattened[finite_mask])
 
         elif self == StatType.QUANTILES:
             flattened = np.hstack(np.hstack(ser.values))
-            return np.quantile(flattened, [0, 0.25, 0.5, 0.75, 1]).tolist()
+            finite_mask = np.isfinite(flattened)
+            if not finite_mask.any():
+                return [np.nan, np.nan, np.nan, np.nan, np.nan]
+            return np.quantile(
+                flattened[finite_mask],
+                q=[0, 0.25, 0.5, 0.75, 1],
+            ).tolist()
 
         elif self == StatType.COUNT:
             count = ser.value_counts(ascending=False)

--- a/torch_frame/data/stats.py
+++ b/torch_frame/data/stats.py
@@ -51,6 +51,7 @@ class StatType(Enum):
             flattened = np.hstack(np.hstack(ser.values))
             finite_mask = np.isfinite(flattened)
             if not finite_mask.any():
+                # NOTE: We may just error out here if eveything is NaN
                 return np.nan
             return np.mean(flattened[finite_mask]).item()
 
@@ -104,6 +105,7 @@ def compute_col_stats(
         ser = ser.mask(ser.isin([np.inf, -np.inf]), np.nan)
 
     if ser.isnull().all():
+        # NOTE: We may just error out here if eveything is NaN
         stats = {
             stat_type: _default_values[stat_type]
             for stat_type in StatType.stats_for_stype(stype)

--- a/torch_frame/data/stats.py
+++ b/torch_frame/data/stats.py
@@ -52,14 +52,14 @@ class StatType(Enum):
             finite_mask = np.isfinite(flattened)
             if not finite_mask.any():
                 return np.nan
-            return np.mean(flattened[finite_mask])
+            return np.mean(flattened[finite_mask]).item()
 
         elif self == StatType.STD:
             flattened = np.hstack(np.hstack(ser.values))
             finite_mask = np.isfinite(flattened)
             if not finite_mask.any():
                 return np.nan
-            return np.std(flattened[finite_mask])
+            return np.std(flattened[finite_mask]).item()
 
         elif self == StatType.QUANTILES:
             flattened = np.hstack(np.hstack(ser.values))


### PR DESCRIPTION
Fixes https://github.com/pyg-team/pytorch-frame/issues/195