### PR TITLE
Support `int` index in `MultiEmbeddingTensor`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Added Cohere embedding example ([#186](https://github.com/pyg-team/pytorch-frame/pull/186))
 - Added `AmazonFineFoodReviews` dataset and OpenAI embedding example ([#182](https://github.com/pyg-team/pytorch-frame/pull/182))
 - Added save and load logic for `FittableBaseTransform` ([#178](https://github.com/pyg-team/pytorch-frame/pull/178))
-- Added `MultiEmbeddingTensor` ([#181](https://github.com/pyg-team/pytorch-frame/pull/181), [#193](https://github.com/pyg-team/pytorch-frame/pull/193))
+- Added `MultiEmbeddingTensor` ([#181](https://github.com/pyg-team/pytorch-frame/pull/181), [#193](https://github.com/pyg-team/pytorch-frame/pull/193), [#198](https://github.com/pyg-team/pytorch-frame/pull/198))
 - Added `to_dense()` for `MultiNestedTensor` ([#170](https://github.com/pyg-team/pytorch-frame/pull/170))
 - Added example for `multicategorical` stype ([#162](https://github.com/pyg-team/pytorch-frame/pull/162))
 - Added `sequence_numerical` stype ([#159](https://github.com/pyg-team/pytorch-frame/pull/159))

--- a/test/data/test_multi_embedding_tensor.py
+++ b/test/data/test_multi_embedding_tensor.py
@@ -123,8 +123,6 @@ def test_index():
             tensor = met_row[0, j]
             assert isinstance(tensor, torch.Tensor)
             assert torch.allclose(tensor_list[j][i], tensor)
-            break
-        break
 
 
 def test_clone():

--- a/test/data/test_multi_embedding_tensor.py
+++ b/test/data/test_multi_embedding_tensor.py
@@ -100,12 +100,31 @@ def test_from_tensor_list():
 
 
 def test_index():
+    num_rows = 8
+    num_cols = 10
     met, tensor_list = get_fake_multi_embedding_tensor(
-        num_rows=2,
-        num_cols=3,
+        num_rows=num_rows,
+        num_cols=num_cols,
     )
-    # case met[i, j]: a tuple of two integers
-    assert_equal(tensor_list, met)
+
+    # Test [i, j] indexing
+    for i in range(-num_rows, num_rows):
+        for j in range(num_cols):
+            tensor = met[i, j]
+            assert isinstance(tensor, torch.Tensor)
+            assert torch.allclose(tensor_list[j][i], tensor)
+
+    # Test [i] indexing
+    for i in range(-num_rows, num_rows):
+        met_row = met[i]
+        assert met_row.shape[0] == 1
+        assert met_row.shape[1] == num_cols
+        for j in range(-num_cols, num_cols):
+            tensor = met_row[0, j]
+            assert isinstance(tensor, torch.Tensor)
+            assert torch.allclose(tensor_list[j][i], tensor)
+            break
+        break
 
 
 def test_clone():

--- a/torch_frame/data/multi_embedding_tensor.py
+++ b/torch_frame/data/multi_embedding_tensor.py
@@ -206,32 +206,3 @@ class MultiEmbeddingTensor(_MultiTensor):
             # which is inconsistent with when dim=0
             offset = torch.LongTensor(offset_list)
             return MultiEmbeddingTensor(num_rows, num_cols, values, offset)
-
-    def _normalize_index(
-        self,
-        index: Union[int, Tensor],
-        dim: int,
-        is_slice_end: bool = False,
-    ) -> Union[int, Tensor]:
-        """Helper function to map negative indices to positive indices and
-        raise :obj:`IndexError` when necessary.
-
-        Args:
-            index: Union[int, Tensor]: Input :obj:`index` with potentially
-                negative elements.
-            is_slice_end (bool): Whether a given index (int) is slice or not.
-                If :obj:`True`, we have more lenient :obj:`IndexError`.
-                (default: :obj:`False`)
-        """
-        dim = self._normalize_dim(dim)
-        max_entries = self.num_rows if dim == 0 else self.num_cols
-        idx_name = "Row" if dim == 0 else "Col"
-        if isinstance(index, int):
-            if index < 0:
-                index = index + max_entries
-            if is_slice_end and index < 0 or index > max_entries:
-                raise IndexError(f"{idx_name} index out of bounds!")
-            elif (not is_slice_end) and (index < 0 or index >= max_entries):
-                raise IndexError(f"{idx_name} index out of bounds!")
-
-        return index

--- a/torch_frame/data/multi_embedding_tensor.py
+++ b/torch_frame/data/multi_embedding_tensor.py
@@ -45,11 +45,21 @@ class MultiEmbeddingTensor(_MultiTensor):
         self,
         index: Any,
     ) -> Union['MultiEmbeddingTensor', Tensor]:
+
         if isinstance(index, tuple) and len(index) == 2 and isinstance(
                 index[0], int) and isinstance(index[1], int):
-            i = index[0]
-            j = index[1]
+            i = self._normalize_index(index[0], dim=0)
+            j = self._normalize_index(index[1], dim=1)
             return self.values[i, self.offset[j]:self.offset[j + 1]]
+
+        if isinstance(index, int):
+            index = self._normalize_index(index, dim=0)
+            return MultiEmbeddingTensor(
+                num_rows=1,
+                num_cols=self.num_cols,
+                values=self.values[index].view(1, -1),
+                offset=self.offset,
+            )
 
         # TODO(akihironitta): Support more index types
         raise NotImplementedError
@@ -196,3 +206,32 @@ class MultiEmbeddingTensor(_MultiTensor):
             # which is inconsistent with when dim=0
             offset = torch.LongTensor(offset_list)
             return MultiEmbeddingTensor(num_rows, num_cols, values, offset)
+
+    def _normalize_index(
+        self,
+        index: Union[int, Tensor],
+        dim: int,
+        is_slice_end: bool = False,
+    ) -> Union[int, Tensor]:
+        """Helper function to map negative indices to positive indices and
+        raise :obj:`IndexError` when necessary.
+
+        Args:
+            index: Union[int, Tensor]: Input :obj:`index` with potentially
+                negative elements.
+            is_slice_end (bool): Whether a given index (int) is slice or not.
+                If :obj:`True`, we have more lenient :obj:`IndexError`.
+                (default: :obj:`False`)
+        """
+        dim = self._normalize_dim(dim)
+        max_entries = self.num_rows if dim == 0 else self.num_cols
+        idx_name = "Row" if dim == 0 else "Col"
+        if isinstance(index, int):
+            if index < 0:
+                index = index + max_entries
+            if is_slice_end and index < 0 or index > max_entries:
+                raise IndexError(f"{idx_name} index out of bounds!")
+            elif (not is_slice_end) and (index < 0 or index >= max_entries):
+                raise IndexError(f"{idx_name} index out of bounds!")
+
+        return index

--- a/torch_frame/data/multi_nested_tensor.py
+++ b/torch_frame/data/multi_nested_tensor.py
@@ -370,44 +370,6 @@ class MultiNestedTensor(_MultiTensor):
         dense[row, col, arange] = self.values
         return dense
 
-    def _normalize_index(
-        self,
-        index: Union[int, Tensor],
-        dim: int,
-        is_slice_end: bool = False,
-    ) -> Union[int, Tensor]:
-        """Helper function to map negative indices to positive indices and
-        raise :obj:`IndexError` when necessary.
-
-        Args:
-            index: Union[int, Tensor]: Input :obj:`index` with potentially
-                negative elements.
-            is_slice_end (bool): Whether a given index (int) is slice or not.
-                If :obj:`True`, we have more lenient :obj:`IndexError`.
-                (default: :obj:`False`)
-        """
-        dim = self._normalize_dim(dim)
-        max_entries = self.num_rows if dim == 0 else self.num_cols
-        idx_name = "Row" if dim == 0 else "Col"
-        if isinstance(index, int):
-            if index < 0:
-                index = index + max_entries
-            if is_slice_end and index < 0 or index > max_entries:
-                raise IndexError(f"{idx_name} index out of bounds!")
-            elif (not is_slice_end) and (index < 0 or index >= max_entries):
-                raise IndexError(f"{idx_name} index out of bounds!")
-        elif isinstance(index, Tensor):
-            assert not is_slice_end
-            assert index.ndim == 1
-            neg_idx = index < 0
-            if neg_idx.any():
-                index = index.clone()
-                index[neg_idx] = max_entries + index[neg_idx]
-            if index.numel() != 0 and (index.min() < 0
-                                       or index.max() >= max_entries):
-                raise IndexError(f"{idx_name} index out of bounds!")
-        return index
-
     # Static methods ##########################################################
     @staticmethod
     def cat(

--- a/torch_frame/data/multi_tensor.py
+++ b/torch_frame/data/multi_tensor.py
@@ -119,8 +119,8 @@ class _MultiTensor:
         Args:
             index: Union[int, Tensor]: Input :obj:`index` with potentially
                 negative elements.
-            is_slice_end (bool): Whether a given index (int) is slice or not.
-                If :obj:`True`, we have more lenient :obj:`IndexError`.
+            is_slice_end (bool): Whether a given index (int) is slice end or
+                not. If :obj:`True`, we have more lenient :obj:`IndexError`.
                 (default: :obj:`False`)
         """
         dim = self._normalize_dim(dim)

--- a/torch_frame/data/multi_tensor.py
+++ b/torch_frame/data/multi_tensor.py
@@ -1,6 +1,6 @@
 import copy
 from dataclasses import dataclass
-from typing import Any, Callable, Tuple
+from typing import Any, Callable, Tuple, Union
 
 import torch
 from torch import Tensor
@@ -106,6 +106,44 @@ class _MultiTensor:
                 "Dimension out of range (expected to be in range of [-2, 1],"
                 f" but got {dim}.")
         return dim
+
+    def _normalize_index(
+        self,
+        index: Union[int, Tensor],
+        dim: int,
+        is_slice_end: bool = False,
+    ) -> Union[int, Tensor]:
+        """Helper function to map negative indices to positive indices and
+        raise :obj:`IndexError` when necessary.
+
+        Args:
+            index: Union[int, Tensor]: Input :obj:`index` with potentially
+                negative elements.
+            is_slice_end (bool): Whether a given index (int) is slice or not.
+                If :obj:`True`, we have more lenient :obj:`IndexError`.
+                (default: :obj:`False`)
+        """
+        dim = self._normalize_dim(dim)
+        max_entries = self.num_rows if dim == 0 else self.num_cols
+        idx_name = "Row" if dim == 0 else "Col"
+        if isinstance(index, int):
+            if index < 0:
+                index = index + max_entries
+            if is_slice_end and index < 0 or index > max_entries:
+                raise IndexError(f"{idx_name} index out of bounds!")
+            elif (not is_slice_end) and (index < 0 or index >= max_entries):
+                raise IndexError(f"{idx_name} index out of bounds!")
+        elif isinstance(index, Tensor):
+            assert not is_slice_end
+            assert index.ndim == 1
+            neg_idx = index < 0
+            if neg_idx.any():
+                index = index.clone()
+                index[neg_idx] = max_entries + index[neg_idx]
+            if index.numel() != 0 and (index.min() < 0
+                                       or index.max() >= max_entries):
+                raise IndexError(f"{idx_name} index out of bounds!")
+        return index
 
     @classmethod
     def allclose(


### PR DESCRIPTION
Part of #88.

```python
import torch
from torch_frame.data import MultiEmbeddingTensor
tensor_list = [
    torch.tensor([[0, 1, 2], [6, 7, 8]]),  # col1
    torch.tensor([[3, 4], [9, 10]]),       # col2
    torch.tensor([[5], [11]]),             # col3
]
met = MultiEmbeddingTensor.from_tensor_list(tensor_list)
print(met)
# MultiEmbeddingTensor(num_rows=2, num_cols=3, device='cpu')
print(met[0])
# MultiEmbeddingTensor(num_rows=1, num_cols=3, device='cpu')
print(met[0].values)
# tensor([[0, 1, 2, 3, 4, 5]])
print(met[0].offset)
# tensor([0, 3, 5, 6])
```