### PR TITLE
Update dev dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ test=[
     "pytest-cov",
 ]
 dev=[
-    "torch_frame[test]",
+    "pytorch_frame[test]",
     "pre-commit",
 ]
 full=[


### PR DESCRIPTION
I've just realised that we were installing https://pypi.org/project/torch-frame/ as one of our dependencies.

Please check and uninstall it from your dev environment:
```bash
pip uninstall torch-frame
```
