### PR TITLE
Config specific `path` during dataset materialization

### DIFF
--- a/examples/llm_embedding.py
+++ b/examples/llm_embedding.py
@@ -98,7 +98,7 @@ dataset = AmazonFineFoodReviews(
     ),
 )
 
-dataset.materialize(path=osp.join(path, 'data.pt'))
+dataset.materialize(path=osp.join(path, f'{args.service}_data.pt'))
 
 # Shuffle the dataset
 dataset = dataset.shuffle()

--- a/examples/transformers_text.py
+++ b/examples/transformers_text.py
@@ -206,7 +206,8 @@ else:
 
 dataset = MultimodalTextBenchmark(root=path, name=args.dataset, **kwargs)
 
-dataset.materialize(path=osp.join(path, 'data.pt'))
+filename = f'{args.model}_{text_stype.value}_data.pt'
+dataset.materialize(path=osp.join(path, filename))
 
 is_classification = dataset.task_type.is_classification
 


### PR DESCRIPTION
Fixes https://github.com/pyg-team/pytorch-frame/issues/154 by using different paths for caching different tensor frame objects.