### PR TITLE
Update the transformers text example

### DIFF
--- a/examples/transformers_text.py
+++ b/examples/transformers_text.py
@@ -42,7 +42,7 @@ from torch_frame.typing import TensorData
 # ===== product_sentiment_machine_hack ======
 # Best Val Acc: 0.9155, Best Test Acc: 0.8971
 # ======== jigsaw_unintended_bias100K =======
-# WIP
+# N/A
 
 # Text Tokenized
 # distilbert-base-uncased + LoRA


### PR DESCRIPTION
Update the transformers text example with
- Fix the data save error when model name contains `/`
- Add mixed precision training, which saves memory and makes the training faster. But unfortunately for some datasets, marked as `N/A` in the comments, may need to tune or adjust the `scaler` scale or clip the gradient norm (https://pytorch.org/docs/stable/generated/torch.nn.utils.clip_grad_norm_.html) to get reasonable results
- Count and print number of finetune parameters for the text encoder.