### PR TITLE
Make `Trompt` output 2d embeddings in `forward`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 
+- Made `Trompt` output 2-dim embeddings in `forward`
+
 ### Deprecated
 
 ### Removed

--- a/test/nn/models/test_compile.py
+++ b/test/nn/models/test_compile.py
@@ -14,7 +14,7 @@ from torch_frame.stype import stype
 from torch_frame.testing import withPackage
 
 
-@withPackage('torch>=2.1.0')
+@withPackage("torch>=2.1.0")
 @pytest.mark.parametrize(
     "model_cls, model_kwargs, stypes, expected_graph_breaks",
     [
@@ -54,7 +54,7 @@ from torch_frame.testing import withPackage
             Trompt,
             dict(channels=8, num_prompts=2),
             None,
-            10,
+            11,
             id="Trompt",
         ),
         pytest.param(

--- a/test/nn/models/test_trompt.py
+++ b/test/nn/models/test_trompt.py
@@ -21,5 +21,7 @@ def test_trompt():
         col_names_dict=tensor_frame.col_names_dict,
     )
     model.reset_parameters()
-    out = model(tensor_frame)
+    out = model.forward_stacked(tensor_frame)
     assert out.shape == (batch_size, num_layers, out_channels)
+    pred = model(tensor_frame)
+    assert pred.shape == (batch_size, out_channels)


### PR DESCRIPTION
so that the behavior of all tensor frame models is aligned.
Instead we add `forward_stacked` that outputs stacked embeddings for layer-wise loss computation.