### PR TITLE
Automatic inference of `in_channels` in `LinearEmbeddingEncoder` for `stype.text_embedding`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ### Deprecated
 
+- No manual passing of `in_channels` to `LinearEmbeddingEncoder` for `stype.text_embedded`
+
 ### Removed
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,7 +33,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ### Removed
 
-- No manual passing of `in_channels` to `LinearEmbeddingEncoder` for `stype.text_embedded`
+- No manual passing of `in_channels` to `LinearEmbeddingEncoder` for `stype.text_embedded` ([#222](https://github.com/pyg-team/pytorch-frame/pull/222))
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ### Deprecated
 
+### Removed
+
 - No manual passing of `in_channels` to `LinearEmbeddingEncoder` for `stype.text_embedded`
 
 ### Removed

--- a/docs/source/get_started/handle_text.rst
+++ b/docs/source/get_started/handle_text.rst
@@ -121,7 +121,7 @@ pre-computed embeddings, which can easily handle :obj:`~torch_frame.stype.text_e
     stype_encoder_dict = {
         stype.categorical: EmbeddingEncoder(),
         stype.numerical: LinearEncoder(),
-        stype.text_embedded: LinearEmbeddingEncoder(in_channels=768)
+        stype.text_embedded: LinearEmbeddingEncoder()
     }
 
 Then, :obj:`stype_encoder_dict` can be directly fed into

--- a/docs/source/get_started/modular_design.rst
+++ b/docs/source/get_started/modular_design.rst
@@ -44,7 +44,7 @@ and :class:`~torch_frame.nn.encoder.LinearEncoder` for encoding `stype.numerical
     stype_encoder_dict = {
         stype.categorical: EmbeddingEncoder(),
         stype.numerical: LinearEncoder(),
-        stype.text_embedded: LinearEmbeddingEncoder(in_channels=768),
+        stype.text_embedded: LinearEmbeddingEncoder(),
     }
 
     encoder = StypeWiseFeatureEncoder(

--- a/examples/llm_embedding.py
+++ b/examples/llm_embedding.py
@@ -20,46 +20,52 @@ from torch_frame.nn import (
 )
 
 parser = argparse.ArgumentParser()
-parser.add_argument('--channels', type=int, default=256)
-parser.add_argument('--num_layers', type=int, default=4)
-parser.add_argument('--batch_size', type=int, default=512)
-parser.add_argument('--lr', type=float, default=0.0001)
-parser.add_argument('--epochs', type=int, default=100)
-parser.add_argument('--seed', type=int, default=0)
-parser.add_argument('--service', type=str, default='voyageai',
-                    choices=['openai', 'cohere', 'voyageai'])
-parser.add_argument('--dataset', type=str, default='wine_reviews')
-parser.add_argument('--api_key', type=str, default=None)
+parser.add_argument("--channels", type=int, default=256)
+parser.add_argument("--num_layers", type=int, default=4)
+parser.add_argument("--batch_size", type=int, default=512)
+parser.add_argument("--lr", type=float, default=0.0001)
+parser.add_argument("--epochs", type=int, default=100)
+parser.add_argument("--seed", type=int, default=0)
+parser.add_argument(
+    "--service",
+    type=str,
+    default="voyageai",
+    choices=["openai", "cohere", "voyageai"],
+)
+parser.add_argument("--dataset", type=str, default="wine_reviews")
+parser.add_argument("--api_key", type=str, default=None)
 args = parser.parse_args()
 
 # Notice that there are 568,454 rows and 2 text columns, it will
 # cost some money to get the text embeddings by using OpenAI API
-if args.service == 'openai':
-    api_key = args.api_key or os.environ.get('OPENAI_API_KEY', None)
+if args.service == "openai":
+    api_key = args.api_key or os.environ.get("OPENAI_API_KEY", None)
     if api_key is None:
-        raise ValueError('OpenAI API key is not specified.')
-elif args.service == 'cohere':
-    api_key = args.api_key or os.environ.get('COHERE_API_KEY', None)
+        raise ValueError("OpenAI API key is not specified.")
+elif args.service == "cohere":
+    api_key = args.api_key or os.environ.get("COHERE_API_KEY", None)
     if api_key is None:
-        raise ValueError('Cohere API key is not specified.')
+        raise ValueError("Cohere API key is not specified.")
 else:
-    api_key = args.api_key or os.environ.get('VOYAGE_API_KEY', None)
+    api_key = args.api_key or os.environ.get("VOYAGE_API_KEY", None)
     if api_key is None:
-        raise ValueError('Voyageai API key is not specified.')
+        raise ValueError("Voyageai API key is not specified.")
 
 
 class OpenAIEmbedding:
     dimension: int = 1536
     text_embedder_batch_size: int = 25
 
-    def __init__(self, model: str = 'text-embedding-ada-002'):
+    def __init__(self, model: str = "text-embedding-ada-002"):
         # Please run `pip install openai` to install the package
         from openai import OpenAI
+
         self.client = OpenAI(api_key=api_key)
         self.model = model
 
     def __call__(self, sentences: List[str]) -> Tensor:
         from openai import Embedding
+
         items: List[Embedding] = self.client.embeddings.create(
             input=sentences, model=self.model).data
         assert len(items) == len(sentences)
@@ -73,14 +79,16 @@ class CohereEmbedding:
     dimension: int = 1024
     text_embedder_batch_size: int = 1000
 
-    def __init__(self, model: str = 'embed-english-v3.0'):
+    def __init__(self, model: str = "embed-english-v3.0"):
         # Please run `pip install cohere` to install the package
         import cohere  # noqa
+
         self.model = model
         self.co = cohere.Client(api_key)
 
     def __call__(self, sentences: List[str]) -> Tensor:
         from cohere import Embeddings
+
         items: Embeddings = self.co.embed(model=self.model, texts=sentences,
                                           input_type="classification")
         assert len(items) == len(sentences)
@@ -92,14 +100,16 @@ class VoyageaiEmbedding:
     dimension: int = 1024
     text_embedder_batch_size: int = 8
 
-    def __init__(self, model: str = 'voyage-01'):
+    def __init__(self, model: str = "voyage-01"):
         # Please run `pip install voyageai` to install the package
         self.model = model
 
     def __call__(self, sentences: List[str]) -> Tensor:
         import voyageai  # noqa
+
         voyageai.api_key = api_key
         from voyageai import get_embeddings
+
         items: List[List[float]] = get_embeddings(sentences, model=self.model)
         assert len(items) == len(sentences)
         embeddings = [torch.FloatTensor(item).view(1, -1) for item in items]
@@ -107,26 +117,33 @@ class VoyageaiEmbedding:
 
 
 torch.manual_seed(args.seed)
-device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
+device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
 
 # Prepare datasets
-path = osp.join(osp.dirname(osp.realpath(__file__)), '..', 'data',
-                'amazon_fine_food_reviews')
+path = osp.join(
+    osp.dirname(osp.realpath(__file__)),
+    "..",
+    "data",
+    "amazon_fine_food_reviews",
+)
 os.makedirs(path, exist_ok=True)
-if args.service == 'openai':
+if args.service == "openai":
     text_encoder = OpenAIEmbedding()
-elif args.service == 'cohere':
+elif args.service == "cohere":
     text_encoder = CohereEmbedding()
 else:
     text_encoder = VoyageaiEmbedding()
 
 dataset = MultimodalTextBenchmark(
-    root=path, name=args.dataset, text_embedder_cfg=TextEmbedderConfig(
+    root=path,
+    name=args.dataset,
+    text_embedder_cfg=TextEmbedderConfig(
         text_embedder=text_encoder,
         batch_size=text_encoder.text_embedder_batch_size,
-    ))
+    ),
+)
 
-dataset.materialize(path=osp.join(path, f'data_{args.service}.pt'))
+dataset.materialize(path=osp.join(path, f"data_{args.service}.pt"))
 
 train_dataset, val_dataset, test_dataset = dataset.split()
 if len(val_dataset) == 0:
@@ -141,8 +158,7 @@ test_loader = DataLoader(test_dataset.tensor_frame, batch_size=args.batch_size)
 stype_encoder_dict = {
     stype.categorical: EmbeddingEncoder(),
     stype.numerical: LinearEncoder(),
-    stype.text_embedded:
-    LinearEmbeddingEncoder(in_channels=text_encoder.dimension)
+    stype.text_embedded: LinearEmbeddingEncoder(),
 }
 
 model = FTTransformer(
@@ -161,7 +177,7 @@ def train(epoch: int) -> float:
     model.train()
     loss_accum = total_count = 0
 
-    for tf in tqdm(train_loader, desc=f'Epoch: {epoch}'):
+    for tf in tqdm(train_loader, desc=f"Epoch: {epoch}"):
         tf = tf.to(device)
         pred = model(tf)
         loss = F.cross_entropy(pred, tf.y)
@@ -189,7 +205,7 @@ def test(loader: DataLoader) -> float:
     return accuracy
 
 
-metric = 'Acc'
+metric = "Acc"
 best_val_metric = 0
 best_test_metric = 0
 
@@ -203,8 +219,8 @@ for epoch in range(1, args.epochs + 1):
         best_val_metric = val_metric
         best_test_metric = test_metric
 
-    print(f'Train Loss: {train_loss:.4f}, Train {metric}: {train_metric:.4f}, '
-          f'Val {metric}: {val_metric:.4f}, Test {metric}: {test_metric:.4f}')
+    print(f"Train Loss: {train_loss:.4f}, Train {metric}: {train_metric:.4f}, "
+          f"Val {metric}: {val_metric:.4f}, Test {metric}: {test_metric:.4f}")
 
-print(f'Best Val {metric}: {best_val_metric:.4f}, '
-      f'Best Test {metric}: {best_test_metric:.4f}')
+print(f"Best Val {metric}: {best_val_metric:.4f}, "
+      f"Best Test {metric}: {best_test_metric:.4f}")

--- a/examples/transformers_text.py
+++ b/examples/transformers_text.py
@@ -45,27 +45,31 @@ from torch_frame.typing import TensorData
 # Best Val Acc: 0.9672, Best Test Acc: 0.9644
 
 parser = argparse.ArgumentParser()
-parser.add_argument('--dataset', type=str, default='wine_reviews')
-parser.add_argument('--channels', type=int, default=256)
-parser.add_argument('--num_layers', type=int, default=4)
-parser.add_argument('--batch_size', type=int, default=512)
-parser.add_argument('--lr', type=float, default=0.0001)
-parser.add_argument('--epochs', type=int, default=100)
-parser.add_argument('--seed', type=int, default=0)
-parser.add_argument('--finetune', action='store_true')
-parser.add_argument('--lora', action='store_true')
+parser.add_argument("--dataset", type=str, default="wine_reviews")
+parser.add_argument("--channels", type=int, default=256)
+parser.add_argument("--num_layers", type=int, default=4)
+parser.add_argument("--batch_size", type=int, default=512)
+parser.add_argument("--lr", type=float, default=0.0001)
+parser.add_argument("--epochs", type=int, default=100)
+parser.add_argument("--seed", type=int, default=0)
+parser.add_argument("--finetune", action="store_true")
+parser.add_argument("--lora", action="store_true")
 parser.add_argument(
-    '--model', type=str, default='distilbert-base-uncased', choices=[
-        'distilbert-base-uncased',
-        'sentence-transformers/all-distilroberta-v1',
-    ])
-parser.add_argument('--pooling', type=str, default='mean',
-                    choices=['mean', 'cls'])
+    "--model",
+    type=str,
+    default="distilbert-base-uncased",
+    choices=[
+        "distilbert-base-uncased",
+        "sentence-transformers/all-distilroberta-v1",
+    ],
+)
+parser.add_argument("--pooling", type=str, default="mean",
+                    choices=["mean", "cls"])
 args = parser.parse_args()
 
 if args.lora and not args.finetune:
-    raise ValueError('Please also specify finetune when '
-                     'choosing LoRA finetuning.')
+    raise ValueError("Please also specify finetune when "
+                     "choosing LoRA finetuning.")
 
 
 class TextToEmbedding:
@@ -76,20 +80,24 @@ class TextToEmbedding:
         self.pooling = pooling
 
     def __call__(self, sentences: List[str]) -> Tensor:
-        inputs = self.tokenizer(sentences, truncation=True,
-                                padding='max_length', return_tensors='pt')
+        inputs = self.tokenizer(
+            sentences,
+            truncation=True,
+            padding="max_length",
+            return_tensors="pt",
+        )
         for key in inputs:
             if isinstance(inputs[key], Tensor):
                 inputs[key] = inputs[key].to(self.device)
         out = self.model(**inputs)
-        mask = inputs['attention_mask']
-        if self.pooling == 'mean':
-            return mean_pooling(out.last_hidden_state.detach(),
-                                mask).squeeze(1).cpu()
-        elif self.pooling == 'cls':
+        mask = inputs["attention_mask"]
+        if self.pooling == "mean":
+            return (mean_pooling(out.last_hidden_state.detach(),
+                                 mask).squeeze(1).cpu())
+        elif self.pooling == "cls":
             return out.last_hidden_state[:, 0, :].detach().cpu()
         else:
-            raise ValueError(f'{self.pooling} is not supported.')
+            raise ValueError(f"{self.pooling} is not supported.")
 
 
 class TextTokenizer:
@@ -100,7 +108,7 @@ class TextTokenizer:
         res = []
         # Tokenize batches of sentences
         inputs = self.tokenizer(sentences, truncation=True, padding=True,
-                                return_tensors='pt')
+                                return_tensors="pt")
         res.append(inputs)
         return res
 
@@ -118,18 +126,18 @@ class TokenToEmbedding(torch.nn.Module):
         lora (bool): Whether using LoRA to finetune the text model.
             (default: :obj:`False`)
     """
-    def __init__(self, model: str, pooling: str = 'mean', lora: bool = False):
+    def __init__(self, model: str, pooling: str = "mean", lora: bool = False):
         super().__init__()
         self.model = AutoModel.from_pretrained(model)
 
         if lora:
-            if model == 'distilbert-base-uncased':
-                target_modules = ['ffn.lin1']
-            elif model == 'sentence-transformers/all-distilroberta-v1':
-                target_modules = ['intermediate.dense']
+            if model == "distilbert-base-uncased":
+                target_modules = ["ffn.lin1"]
+            elif model == "sentence-transformers/all-distilroberta-v1":
+                target_modules = ["intermediate.dense"]
             else:
-                raise ValueError(f'Model {model} is not specified for '
-                                 f'LoRA finetuning.')
+                raise ValueError(f"Model {model} is not specified for "
+                                 f"LoRA finetuning.")
 
             peft_config = LoraConfig(
                 task_type=TaskType.FEATURE_EXTRACTION,
@@ -137,7 +145,7 @@ class TokenToEmbedding(torch.nn.Module):
                 lora_alpha=32,
                 inference_mode=False,
                 lora_dropout=0.1,
-                bias='none',
+                bias="none",
                 target_modules=target_modules,
             )
             self.model = get_peft_model(self.model, peft_config)
@@ -145,26 +153,26 @@ class TokenToEmbedding(torch.nn.Module):
 
     def forward(self, feat: TensorData) -> Tensor:
         # [batch_size, num_cols, batch_max_seq_len]
-        input_ids = feat['input_ids'].to_dense(fill_value=0)
-        mask = feat['attention_mask'].to_dense(fill_value=0)
+        input_ids = feat["input_ids"].to_dense(fill_value=0)
+        mask = feat["attention_mask"].to_dense(fill_value=0)
         outs = []
         # Get text embeddings over each column
         for i in range(input_ids.shape[1]):
             out = self.model(input_ids=input_ids[:, i, :],
                              attention_mask=mask[:, i, :])
-            if self.pooling == 'mean':
+            if self.pooling == "mean":
                 outs.append(mean_pooling(out.last_hidden_state, mask[:, i, :]))
-            elif self.pooling == 'cls':
+            elif self.pooling == "cls":
                 outs.append(out.last_hidden_state[:, 0, :].unsqueeze(1))
             else:
-                raise ValueError(f'{self.pooling} is not supported.')
+                raise ValueError(f"{self.pooling} is not supported.")
         # Concatenate output embeddings for different columns
         return torch.cat(outs, dim=1)
 
 
 def mean_pooling(last_hidden_state: Tensor, attention_mask) -> Tensor:
-    input_mask_expanded = attention_mask.unsqueeze(-1).expand(
-        last_hidden_state.size()).float()
+    input_mask_expanded = (attention_mask.unsqueeze(-1).expand(
+        last_hidden_state.size()).float())
     embedding = torch.sum(
         last_hidden_state * input_mask_expanded, dim=1) / torch.clamp(
             input_mask_expanded.sum(1), min=1e-9)
@@ -172,10 +180,10 @@ def mean_pooling(last_hidden_state: Tensor, attention_mask) -> Tensor:
 
 
 torch.manual_seed(args.seed)
-device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
+device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
 
 # Prepare datasets
-path = osp.join(osp.dirname(osp.realpath(__file__)), '..', 'data',
+path = osp.join(osp.dirname(osp.realpath(__file__)), "..", "data",
                 args.dataset)
 
 # Prepare text columns
@@ -183,11 +191,11 @@ if not args.finetune:
     text_encoder = TextToEmbedding(model=args.model, pooling=args.pooling,
                                    device=device)
     text_stype = torch_frame.text_embedded
-    text_stype_encoder = LinearEmbeddingEncoder(in_channels=768)
+    text_stype_encoder = LinearEmbeddingEncoder()
     kwargs = {
-        'text_stype':
+        "text_stype":
         text_stype,
-        'text_embedder_cfg':
+        "text_embedder_cfg":
         TextEmbedderConfig(text_embedder=text_encoder, batch_size=5),
     }
 else:
@@ -198,15 +206,15 @@ else:
     text_stype_encoder = LinearModelEncoder(in_channels=768,
                                             model=text_encoder)
     kwargs = {
-        'text_stype':
+        "text_stype":
         text_stype,
-        'text_tokenizer_cfg':
+        "text_tokenizer_cfg":
         TextTokenizerConfig(text_tokenizer=text_tokenizer, batch_size=10000),
     }
 
 dataset = MultimodalTextBenchmark(root=path, name=args.dataset, **kwargs)
 
-filename = f'{args.model}_{text_stype.value}_data.pt'
+filename = f"{args.model}_{text_stype.value}_data.pt"
 dataset.materialize(path=osp.join(path, filename))
 
 is_classification = dataset.task_type.is_classification
@@ -251,7 +259,7 @@ def train(epoch: int) -> float:
     model.train()
     loss_accum = total_count = 0
 
-    for tf in tqdm(train_loader, desc=f'Epoch: {epoch}'):
+    for tf in tqdm(train_loader, desc=f"Epoch: {epoch}"):
         tf = tf.to(device)
         pred = model(tf)
         if is_classification:
@@ -279,7 +287,7 @@ def test(loader: DataLoader) -> float:
             accum += float((tf.y == pred_class).sum())
         else:
             accum += float(
-                F.mse_loss(pred.view(-1), tf.y.view(-1), reduction='sum'))
+                F.mse_loss(pred.view(-1), tf.y.view(-1), reduction="sum"))
         total_count += len(tf.y)
 
     if is_classification:
@@ -291,13 +299,13 @@ def test(loader: DataLoader) -> float:
 
 
 if is_classification:
-    metric = 'Acc'
+    metric = "Acc"
     best_val_metric = 0
     best_test_metric = 0
 else:
-    metric = 'RMSE'
-    best_val_metric = float('inf')
-    best_test_metric = float('inf')
+    metric = "RMSE"
+    best_val_metric = float("inf")
+    best_test_metric = float("inf")
 
 for epoch in range(1, args.epochs + 1):
     train_loss = train(epoch)
@@ -312,8 +320,8 @@ for epoch in range(1, args.epochs + 1):
         best_val_metric = val_metric
         best_test_metric = test_metric
 
-    print(f'Train Loss: {train_loss:.4f}, Train {metric}: {train_metric:.4f}, '
-          f'Val {metric}: {val_metric:.4f}, Test {metric}: {test_metric:.4f}')
+    print(f"Train Loss: {train_loss:.4f}, Train {metric}: {train_metric:.4f}, "
+          f"Val {metric}: {val_metric:.4f}, Test {metric}: {test_metric:.4f}")
 
-print(f'Best Val {metric}: {best_val_metric:.4f}, '
-      f'Best Test {metric}: {best_test_metric:.4f}')
+print(f"Best Val {metric}: {best_val_metric:.4f}, "
+      f"Best Test {metric}: {best_test_metric:.4f}")

--- a/test/nn/encoder/test_stype_encoder.py
+++ b/test/nn/encoder/test_stype_encoder.py
@@ -27,7 +27,7 @@ from torch_frame.testing.text_tokenizer import (
 )
 
 
-@pytest.mark.parametrize('encoder_cls_kwargs', [(EmbeddingEncoder, {})])
+@pytest.mark.parametrize("encoder_cls_kwargs", [(EmbeddingEncoder, {})])
 def test_categorical_feature_encoder(encoder_cls_kwargs):
     dataset: Dataset = FakeDataset(num_rows=10, with_nan=False)
     dataset.materialize()
@@ -36,9 +36,12 @@ def test_categorical_feature_encoder(encoder_cls_kwargs):
         dataset.col_stats[col_name]
         for col_name in tensor_frame.col_names_dict[stype.categorical]
     ]
-    encoder = encoder_cls_kwargs[0](8, stats_list=stats_list,
-                                    stype=stype.categorical,
-                                    **encoder_cls_kwargs[1])
+    encoder = encoder_cls_kwargs[0](
+        8,
+        stats_list=stats_list,
+        stype=stype.categorical,
+        **encoder_cls_kwargs[1],
+    )
     feat_cat = tensor_frame.feat_dict[stype.categorical]
     x = encoder(feat_cat)
     assert x.shape == (feat_cat.size(0), feat_cat.size(1), 8)
@@ -51,30 +54,42 @@ def test_categorical_feature_encoder(encoder_cls_kwargs):
     assert (x_perturbed[:, 1:, :] == x[:, 1:, :]).all()
 
 
-@pytest.mark.parametrize('encoder_cls_kwargs', [
-    (LinearEncoder, {}),
-    (LinearEncoder, {
-        'post_module': ReLU(),
-    }),
-    (LinearBucketEncoder, {}),
-    (LinearBucketEncoder, {
-        'post_module': ReLU()
-    }),
-    (LinearEncoder, {
-        'post_module': ReLU()
-    }),
-    (LinearPeriodicEncoder, {
-        'n_bins': 4
-    }),
-    (LinearPeriodicEncoder, {
-        'n_bins': 4,
-        'post_module': ReLU(),
-    }),
-    (ExcelFormerEncoder, {
-        'post_module': ReLU(),
-    }),
-    (StackEncoder, {}),
-])
+@pytest.mark.parametrize(
+    "encoder_cls_kwargs",
+    [
+        (LinearEncoder, {}),
+        (
+            LinearEncoder,
+            {
+                "post_module": ReLU(),
+            },
+        ),
+        (LinearBucketEncoder, {}),
+        (LinearBucketEncoder, {
+            "post_module": ReLU()
+        }),
+        (LinearEncoder, {
+            "post_module": ReLU()
+        }),
+        (LinearPeriodicEncoder, {
+            "n_bins": 4
+        }),
+        (
+            LinearPeriodicEncoder,
+            {
+                "n_bins": 4,
+                "post_module": ReLU(),
+            },
+        ),
+        (
+            ExcelFormerEncoder,
+            {
+                "post_module": ReLU(),
+            },
+        ),
+        (StackEncoder, {}),
+    ],
+)
 def test_numerical_feature_encoder(encoder_cls_kwargs):
     dataset: Dataset = FakeDataset(num_rows=10, with_nan=False)
     dataset.materialize()
@@ -90,26 +105,32 @@ def test_numerical_feature_encoder(encoder_cls_kwargs):
     feat_num = tensor_frame.feat_dict[stype.numerical]
     x = encoder(feat_num)
     assert x.shape == (feat_num.size(0), feat_num.size(1), 8)
-    if 'post_module' in encoder_cls_kwargs[1]:
+    if "post_module" in encoder_cls_kwargs[1]:
         assert encoder.post_module is not None
     else:
         assert encoder.post_module is None
 
     # Perturb the first column
-    feat_num[:, 0] = feat_num[:, 0] + 10.
+    feat_num[:, 0] = feat_num[:, 0] + 10.0
     x_perturbed = encoder(feat_num)
     # Make sure other column embeddings are unchanged
     assert (x_perturbed[:, 1:, :] == x[:, 1:, :]).all()
 
 
-@pytest.mark.parametrize('encoder_cls_kwargs',
-                         [(MultiCategoricalEmbeddingEncoder, {
-                             'mode': 'mean'
-                         }), (MultiCategoricalEmbeddingEncoder, {
-                             'mode': 'sum'
-                         }), (MultiCategoricalEmbeddingEncoder, {
-                             'mode': 'max'
-                         })])
+@pytest.mark.parametrize(
+    "encoder_cls_kwargs",
+    [
+        (MultiCategoricalEmbeddingEncoder, {
+            "mode": "mean"
+        }),
+        (MultiCategoricalEmbeddingEncoder, {
+            "mode": "sum"
+        }),
+        (MultiCategoricalEmbeddingEncoder, {
+            "mode": "max"
+        }),
+    ],
+)
 def test_multicategorical_feature_encoder(encoder_cls_kwargs):
     dataset: Dataset = FakeDataset(num_rows=10,
                                    stypes=[stype.multicategorical],
@@ -120,9 +141,12 @@ def test_multicategorical_feature_encoder(encoder_cls_kwargs):
         dataset.col_stats[col_name]
         for col_name in tensor_frame.col_names_dict[stype.multicategorical]
     ]
-    encoder = encoder_cls_kwargs[0](8, stats_list=stats_list,
-                                    stype=stype.multicategorical,
-                                    **encoder_cls_kwargs[1])
+    encoder = encoder_cls_kwargs[0](
+        8,
+        stats_list=stats_list,
+        stype=stype.multicategorical,
+        **encoder_cls_kwargs[1],
+    )
     feat_multicat = tensor_frame.feat_dict[stype.multicategorical]
     x = encoder(feat_multicat)
     assert x.shape == (feat_multicat.size(0), feat_multicat.size(1), 8)
@@ -136,11 +160,17 @@ def test_multicategorical_feature_encoder(encoder_cls_kwargs):
     assert (x_perturbed[:, 1:, :] == x[:, 1:, :]).all()
 
 
-@pytest.mark.parametrize('encoder_cls_kwargs', [
-    (EmbeddingEncoder, {
-        'na_strategy': NAStrategy.MOST_FREQUENT,
-    }),
-])
+@pytest.mark.parametrize(
+    "encoder_cls_kwargs",
+    [
+        (
+            EmbeddingEncoder,
+            {
+                "na_strategy": NAStrategy.MOST_FREQUENT,
+            },
+        ),
+    ],
+)
 def test_categorical_feature_encoder_with_nan(encoder_cls_kwargs):
     dataset: Dataset = FakeDataset(num_rows=10, with_nan=True)
     dataset.materialize()
@@ -150,9 +180,12 @@ def test_categorical_feature_encoder_with_nan(encoder_cls_kwargs):
         for col_name in tensor_frame.col_names_dict[stype.categorical]
     ]
 
-    encoder = encoder_cls_kwargs[0](8, stats_list=stats_list,
-                                    stype=stype.categorical,
-                                    **encoder_cls_kwargs[1])
+    encoder = encoder_cls_kwargs[0](
+        8,
+        stats_list=stats_list,
+        stype=stype.categorical,
+        **encoder_cls_kwargs[1],
+    )
     feat_cat = tensor_frame.feat_dict[stype.categorical]
     isnan_mask = feat_cat == -1
     x = encoder(feat_cat)
@@ -163,14 +196,23 @@ def test_categorical_feature_encoder_with_nan(encoder_cls_kwargs):
     assert (feat_cat[isnan_mask] == -1).all()
 
 
-@pytest.mark.parametrize('encoder_cls_kwargs', [
-    (LinearEncoder, {
-        'na_strategy': NAStrategy.ZEROS,
-    }),
-    (LinearEncoder, {
-        'na_strategy': NAStrategy.MEAN,
-    }),
-])
+@pytest.mark.parametrize(
+    "encoder_cls_kwargs",
+    [
+        (
+            LinearEncoder,
+            {
+                "na_strategy": NAStrategy.ZEROS,
+            },
+        ),
+        (
+            LinearEncoder,
+            {
+                "na_strategy": NAStrategy.MEAN,
+            },
+        ),
+    ],
+)
 def test_numerical_feature_encoder_with_nan(encoder_cls_kwargs):
     dataset: Dataset = FakeDataset(num_rows=10, with_nan=True)
     dataset.materialize()
@@ -192,11 +234,16 @@ def test_numerical_feature_encoder_with_nan(encoder_cls_kwargs):
     assert feat_num[isnan_mask].isnan().all()
 
 
-@pytest.mark.parametrize('encoder_cls_kwargs',
-                         [(MultiCategoricalEmbeddingEncoder, {
-                             'mode': 'mean',
-                             'na_strategy': NAStrategy.ZEROS
-                         })])
+@pytest.mark.parametrize(
+    "encoder_cls_kwargs",
+    [(
+        MultiCategoricalEmbeddingEncoder,
+        {
+            "mode": "mean",
+            "na_strategy": NAStrategy.ZEROS
+        },
+    )],
+)
 def test_multicategorical_feature_encoder_with_nan(encoder_cls_kwargs):
     dataset: Dataset = FakeDataset(num_rows=10,
                                    stypes=[stype.multicategorical],
@@ -209,9 +256,12 @@ def test_multicategorical_feature_encoder_with_nan(encoder_cls_kwargs):
         for col_name in tensor_frame.col_names_dict[stype.multicategorical]
     ]
 
-    encoder = encoder_cls_kwargs[0](8, stats_list=stats_list,
-                                    stype=stype.multicategorical,
-                                    **encoder_cls_kwargs[1])
+    encoder = encoder_cls_kwargs[0](
+        8,
+        stats_list=stats_list,
+        stype=stype.multicategorical,
+        **encoder_cls_kwargs[1],
+    )
     feat_multicat = tensor_frame.feat_dict[stype.multicategorical]
     isnan_mask = feat_multicat.values == -1
     x = encoder(feat_multicat)
@@ -243,15 +293,18 @@ def test_text_embedded_encoder():
         dataset.col_stats[col_name]
         for col_name in tensor_frame.col_names_dict[stype.text_embedded]
     ]
-    encoder = LinearEmbeddingEncoder(out_channels=out_channels,
-                                     stats_list=stats_list,
-                                     stype=stype.text_embedded,
-                                     in_channels=text_emb_channels)
+    encoder = LinearEmbeddingEncoder(
+        out_channels=out_channels,
+        stats_list=stats_list,
+        stype=stype.text_embedded,
+    )
     x_text = tensor_frame.feat_dict[stype.text_embedded]
     x = encoder(x_text)
-    assert x.shape == (num_rows,
-                       len(tensor_frame.col_names_dict[stype.text_embedded]),
-                       out_channels)
+    assert x.shape == (
+        num_rows,
+        len(tensor_frame.col_names_dict[stype.text_embedded]),
+        out_channels,
+    )
 
 
 def test_text_tokenized_encoder():
@@ -268,7 +321,9 @@ def test_text_tokenized_encoder():
         ],
         text_tokenizer_cfg=TextTokenizerConfig(
             text_tokenizer=WhiteSpaceHashTokenizer(
-                num_hash_bins=num_hash_bins), batch_size=None),
+                num_hash_bins=num_hash_bins),
+            batch_size=None,
+        ),
     )
     dataset.materialize()
     tensor_frame = dataset.tensor_frame
@@ -278,7 +333,8 @@ def test_text_tokenized_encoder():
     ]
     model = RandomTextModel(
         text_emb_channels=text_emb_channels,
-        num_cols=len(tensor_frame.col_names_dict[stype.text_tokenized]))
+        num_cols=len(tensor_frame.col_names_dict[stype.text_tokenized]),
+    )
     encoder = LinearModelEncoder(
         out_channels=out_channels,
         stats_list=stats_list,
@@ -288,6 +344,8 @@ def test_text_tokenized_encoder():
     )
     x_text = tensor_frame.feat_dict[stype.text_tokenized]
     x = encoder(x_text)
-    assert x.shape == (num_rows,
-                       len(tensor_frame.col_names_dict[stype.text_tokenized]),
-                       out_channels)
+    assert x.shape == (
+        num_rows,
+        len(tensor_frame.col_names_dict[stype.text_tokenized]),
+        out_channels,
+    )

--- a/test/nn/encoder/test_stype_encoder.py
+++ b/test/nn/encoder/test_stype_encoder.py
@@ -54,42 +54,30 @@ def test_categorical_feature_encoder(encoder_cls_kwargs):
     assert (x_perturbed[:, 1:, :] == x[:, 1:, :]).all()
 
 
-@pytest.mark.parametrize(
-    "encoder_cls_kwargs",
-    [
-        (LinearEncoder, {}),
-        (
-            LinearEncoder,
-            {
-                "post_module": ReLU(),
-            },
-        ),
-        (LinearBucketEncoder, {}),
-        (LinearBucketEncoder, {
-            "post_module": ReLU()
-        }),
-        (LinearEncoder, {
-            "post_module": ReLU()
-        }),
-        (LinearPeriodicEncoder, {
-            "n_bins": 4
-        }),
-        (
-            LinearPeriodicEncoder,
-            {
-                "n_bins": 4,
-                "post_module": ReLU(),
-            },
-        ),
-        (
-            ExcelFormerEncoder,
-            {
-                "post_module": ReLU(),
-            },
-        ),
-        (StackEncoder, {}),
-    ],
-)
+@pytest.mark.parametrize('encoder_cls_kwargs', [
+    (LinearEncoder, {}),
+    (LinearEncoder, {
+        'post_module': ReLU(),
+    }),
+    (LinearBucketEncoder, {}),
+    (LinearBucketEncoder, {
+        'post_module': ReLU()
+    }),
+    (LinearEncoder, {
+        'post_module': ReLU()
+    }),
+    (LinearPeriodicEncoder, {
+        'n_bins': 4
+    }),
+    (LinearPeriodicEncoder, {
+        'n_bins': 4,
+        'post_module': ReLU(),
+    }),
+    (ExcelFormerEncoder, {
+        'post_module': ReLU(),
+    }),
+    (StackEncoder, {}),
+])
 def test_numerical_feature_encoder(encoder_cls_kwargs):
     dataset: Dataset = FakeDataset(num_rows=10, with_nan=False)
     dataset.materialize()
@@ -160,17 +148,11 @@ def test_multicategorical_feature_encoder(encoder_cls_kwargs):
     assert (x_perturbed[:, 1:, :] == x[:, 1:, :]).all()
 
 
-@pytest.mark.parametrize(
-    "encoder_cls_kwargs",
-    [
-        (
-            EmbeddingEncoder,
-            {
-                "na_strategy": NAStrategy.MOST_FREQUENT,
-            },
-        ),
-    ],
-)
+@pytest.mark.parametrize('encoder_cls_kwargs', [
+    (EmbeddingEncoder, {
+        'na_strategy': NAStrategy.MOST_FREQUENT,
+    }),
+])
 def test_categorical_feature_encoder_with_nan(encoder_cls_kwargs):
     dataset: Dataset = FakeDataset(num_rows=10, with_nan=True)
     dataset.materialize()
@@ -196,23 +178,14 @@ def test_categorical_feature_encoder_with_nan(encoder_cls_kwargs):
     assert (feat_cat[isnan_mask] == -1).all()
 
 
-@pytest.mark.parametrize(
-    "encoder_cls_kwargs",
-    [
-        (
-            LinearEncoder,
-            {
-                "na_strategy": NAStrategy.ZEROS,
-            },
-        ),
-        (
-            LinearEncoder,
-            {
-                "na_strategy": NAStrategy.MEAN,
-            },
-        ),
-    ],
-)
+@pytest.mark.parametrize('encoder_cls_kwargs', [
+    (LinearEncoder, {
+        'na_strategy': NAStrategy.ZEROS,
+    }),
+    (LinearEncoder, {
+        'na_strategy': NAStrategy.MEAN,
+    }),
+])
 def test_numerical_feature_encoder_with_nan(encoder_cls_kwargs):
     dataset: Dataset = FakeDataset(num_rows=10, with_nan=True)
     dataset.materialize()

--- a/test/nn/encoder/test_stypewise_encoder.py
+++ b/test/nn/encoder/test_stypewise_encoder.py
@@ -22,28 +22,41 @@ from torch_frame.testing.text_tokenizer import (
 )
 
 
-@pytest.mark.parametrize('encoder_cat_cls_kwargs', [(EmbeddingEncoder, {})])
-@pytest.mark.parametrize('encoder_num_cls_kwargs', [
-    (LinearEncoder, {}),
-    (LinearBucketEncoder, {}),
-    (LinearPeriodicEncoder, {
-        'n_bins': 4
-    }),
-])
-@pytest.mark.parametrize('encoder_multicategorical_cls_kwargs', [
-    (MultiCategoricalEmbeddingEncoder, {}),
-])
-@pytest.mark.parametrize('encoder_text_embedded_cls_kwargs', [
-    (LinearEmbeddingEncoder, {
-        'in_channels': 12
-    }),
-])
-@pytest.mark.parametrize('encoder_text_tokenized_cls_kwargs', [
-    (LinearModelEncoder, {
-        'model': RandomTextModel(12, 2),
-        'in_channels': 12,
-    }),
-])
+@pytest.mark.parametrize("encoder_cat_cls_kwargs", [(EmbeddingEncoder, {})])
+@pytest.mark.parametrize(
+    "encoder_num_cls_kwargs",
+    [
+        (LinearEncoder, {}),
+        (LinearBucketEncoder, {}),
+        (LinearPeriodicEncoder, {
+            "n_bins": 4
+        }),
+    ],
+)
+@pytest.mark.parametrize(
+    "encoder_multicategorical_cls_kwargs",
+    [
+        (MultiCategoricalEmbeddingEncoder, {}),
+    ],
+)
+@pytest.mark.parametrize(
+    "encoder_text_embedded_cls_kwargs",
+    [
+        (LinearEmbeddingEncoder, {}),
+    ],
+)
+@pytest.mark.parametrize(
+    "encoder_text_tokenized_cls_kwargs",
+    [
+        (
+            LinearModelEncoder,
+            {
+                "model": RandomTextModel(12, 2),
+                "in_channels": 12,
+            },
+        ),
+    ],
+)
 def test_stypewise_feature_encoder(
     encoder_cat_cls_kwargs,
     encoder_num_cls_kwargs,
@@ -56,12 +69,14 @@ def test_stypewise_feature_encoder(
         num_rows=num_rows,
         with_nan=False,
         stypes=[
-            stype.categorical, stype.numerical, stype.multicategorical,
-            stype.text_embedded, stype.text_tokenized
+            stype.categorical,
+            stype.numerical,
+            stype.multicategorical,
+            stype.text_embedded,
+            stype.text_tokenized,
         ],
         text_embedder_cfg=TextEmbedderConfig(
-            text_embedder=HashTextEmbedder(
-                encoder_text_embedded_cls_kwargs[1]['in_channels']),
+            text_embedder=HashTextEmbedder(out_channels=16, ),
             batch_size=None,
         ),
         text_tokenizer_cfg=TextTokenizerConfig(
@@ -96,15 +111,15 @@ def test_stypewise_feature_encoder(
     x, col_names = encoder(tensor_frame)
     assert x.shape == (num_rows, tensor_frame.num_cols, out_channels)
     assert col_names == [
-        'num_1',
-        'num_2',
-        'num_3',
-        'cat_1',
-        'cat_2',
-        'text_embedded_1',
-        'text_embedded_2',
-        'text_tokenized_1',
-        'text_tokenized_2',
-        'multicat_1',
-        'multicat_2',
+        "num_1",
+        "num_2",
+        "num_3",
+        "cat_1",
+        "cat_2",
+        "text_embedded_1",
+        "text_embedded_2",
+        "text_tokenized_1",
+        "text_tokenized_2",
+        "multicat_1",
+        "multicat_2",
     ]

--- a/test/nn/encoder/test_stypewise_encoder.py
+++ b/test/nn/encoder/test_stypewise_encoder.py
@@ -34,9 +34,7 @@ from torch_frame.testing.text_tokenizer import (
     (MultiCategoricalEmbeddingEncoder, {}),
 ])
 @pytest.mark.parametrize('encoder_text_embedded_cls_kwargs', [
-    (LinearEmbeddingEncoder, {
-        'in_channels': 12
-    }),
+    (LinearEmbeddingEncoder, {}),
 ])
 @pytest.mark.parametrize('encoder_text_tokenized_cls_kwargs', [
     (LinearModelEncoder, {

--- a/test/nn/encoder/test_stypewise_encoder.py
+++ b/test/nn/encoder/test_stypewise_encoder.py
@@ -22,41 +22,28 @@ from torch_frame.testing.text_tokenizer import (
 )
 
 
-@pytest.mark.parametrize("encoder_cat_cls_kwargs", [(EmbeddingEncoder, {})])
-@pytest.mark.parametrize(
-    "encoder_num_cls_kwargs",
-    [
-        (LinearEncoder, {}),
-        (LinearBucketEncoder, {}),
-        (LinearPeriodicEncoder, {
-            "n_bins": 4
-        }),
-    ],
-)
-@pytest.mark.parametrize(
-    "encoder_multicategorical_cls_kwargs",
-    [
-        (MultiCategoricalEmbeddingEncoder, {}),
-    ],
-)
-@pytest.mark.parametrize(
-    "encoder_text_embedded_cls_kwargs",
-    [
-        (LinearEmbeddingEncoder, {}),
-    ],
-)
-@pytest.mark.parametrize(
-    "encoder_text_tokenized_cls_kwargs",
-    [
-        (
-            LinearModelEncoder,
-            {
-                "model": RandomTextModel(12, 2),
-                "in_channels": 12,
-            },
-        ),
-    ],
-)
+@pytest.mark.parametrize('encoder_cat_cls_kwargs', [(EmbeddingEncoder, {})])
+@pytest.mark.parametrize('encoder_num_cls_kwargs', [
+    (LinearEncoder, {}),
+    (LinearBucketEncoder, {}),
+    (LinearPeriodicEncoder, {
+        'n_bins': 4
+    }),
+])
+@pytest.mark.parametrize('encoder_multicategorical_cls_kwargs', [
+    (MultiCategoricalEmbeddingEncoder, {}),
+])
+@pytest.mark.parametrize('encoder_text_embedded_cls_kwargs', [
+    (LinearEmbeddingEncoder, {
+        'in_channels': 12
+    }),
+])
+@pytest.mark.parametrize('encoder_text_tokenized_cls_kwargs', [
+    (LinearModelEncoder, {
+        'model': RandomTextModel(12, 2),
+        'in_channels': 12,
+    }),
+])
 def test_stypewise_feature_encoder(
     encoder_cat_cls_kwargs,
     encoder_num_cls_kwargs,


### PR DESCRIPTION
Based on suggestion https://github.com/pyg-team/pytorch-frame/issues/206#issuecomment-1811525804

A lot of diff is due to the new formatter: charliermarsh.ruff