### PR TITLE
Fix `[:, int]` indexing in `MultiEmbeddingTensor`

### DIFF
--- a/torch_frame/data/multi_embedding_tensor.py
+++ b/torch_frame/data/multi_embedding_tensor.py
@@ -325,11 +325,18 @@ class MultiEmbeddingTensor(_MultiTensor):
             )
         elif dim == 1:
             value_index = slice(self.offset[index], self.offset[index + 1])
+            values = self.values[:, value_index]
+            offset_list = [0, self.offset[index + 1] - self.offset[index]]
+            offset = torch.tensor(
+                offset_list,
+                dtype=torch.long,
+                device=self.device,
+            )
             return MultiEmbeddingTensor(
                 num_rows=self.num_rows,
                 num_cols=1,
-                values=self.values[:, value_index],
-                offset=self.offset[[0, index + 1]],
+                values=values,
+                offset=offset,
             )
 
     @staticmethod


### PR DESCRIPTION
Fixes a bug in `[:, int]` indexing in `MultiEmbeddingTensor` caught by this new test case:
```python
assert_equal(
        tensor_list,
        MultiEmbeddingTensor.cat(
            [met[:, i] for i in range(met.size(1))],
            dim=1,
        ),
    )
```

Addresses https://github.com/pyg-team/pytorch-frame/pull/193#discussion_r1387650926 (cc @weihua916)
Addresses https://github.com/pyg-team/pytorch-frame/pull/181#discussion_r1383949234 (cc @yiweny)

---

No changelog entry needed as the feature hasn't been released yet.