### PR TITLE
Add `LinearMultiEmbeddingEncoder` for `embedding` stype

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
+- Added `LinearMultiEmbeddingEncoder` for `embedding` stype ([#243](https://github.com/pyg-team/pytorch-frame/pull/243))
 - Added support for `torch_frame.text_embedded` in `GBDT` ([#239](https://github.com/pyg-team/pytorch-frame/pull/239))
 - Support `Metric` in `GBDT` ([#236](https://github.com/pyg-team/pytorch-frame/pull/236))
 - Added auto-inference of `stype` ([#221](https://github.com/pyg-team/pytorch-frame/pull/221))

--- a/test/data/test_stats.py
+++ b/test/data/test_stats.py
@@ -7,6 +7,7 @@ from torch_frame.data.stats import StatType, compute_col_stats
 from torch_frame.datasets.fake import _random_timestamp
 from torch_frame.stype import (
     categorical,
+    embedding,
     multicategorical,
     numerical,
     sequence_numerical,
@@ -14,7 +15,7 @@ from torch_frame.stype import (
 )
 
 
-def test_compute_col_stats_all_numerical():
+def test_compute_col_stats_numerical():
     ser = pd.Series([1, 2, 3])
     stype = numerical
     assert compute_col_stats(ser, stype) == {
@@ -24,7 +25,7 @@ def test_compute_col_stats_all_numerical():
     }
 
 
-def test_compute_col_stats_all_categorical():
+def test_compute_col_stats_categorical():
     ser = pd.Series(['a', 'a', 'a', 'b', 'c'])
     stype = categorical
     assert compute_col_stats(ser, stype) == {
@@ -32,7 +33,7 @@ def test_compute_col_stats_all_categorical():
     }
 
 
-def test_compute_col_stats_all_multi_categorical():
+def test_compute_col_stats_multi_categorical():
     for ser in [
             pd.Series(['a|a|b', 'a|c', 'c|a', 'a|b|c', '', None]),
             # # Testing with leading and traling whitespace
@@ -47,7 +48,7 @@ def test_compute_col_stats_all_multi_categorical():
         }
 
 
-def test_compute_col_stats_all_timestamp():
+def test_compute_col_stats_timestamp():
     start_date = datetime(2000, 1, 1)
     end_date = datetime(2023, 1, 1)
     num_rows = 10
@@ -82,7 +83,7 @@ def test_compute_col_stats_all_timestamp():
     assert (year_range[0] == year_range[1] == 1900)
 
 
-def test_compute_col_stats_all_timestamp_with_all_nan():
+def test_compute_col_stats_timestamp_with_nan():
     ser = pd.Series([np.nan, np.nan, np.nan, np.nan, np.nan, np.nan, np.nan])
     stype = timestamp
     year_range = compute_col_stats(ser, stype)[StatType.YEAR_RANGE]
@@ -90,7 +91,7 @@ def test_compute_col_stats_all_timestamp_with_all_nan():
     assert np.isnan(year_range[0]) and np.isnan(year_range[1])
 
 
-def test_compute_col_stats_all_sequence_numerical():
+def test_compute_col_stats_sequence_numerical():
     ser = pd.Series([[1, 2, 3], [4, 5, 6]])
     stype = sequence_numerical
     assert compute_col_stats(ser, stype) == {
@@ -100,7 +101,7 @@ def test_compute_col_stats_all_sequence_numerical():
     }
 
 
-def test_compute_col_stats_all_sequence_numerical_with_nan_inf():
+def test_compute_col_stats_sequence_numerical_with_nan_inf():
     ser = pd.Series([[1, 2, 3, np.nan], [4, 5, 6]])
     expected_col_stats = {
         StatType.MEAN: 3.5,
@@ -113,7 +114,7 @@ def test_compute_col_stats_all_sequence_numerical_with_nan_inf():
     assert compute_col_stats(ser, stype) == expected_col_stats
 
 
-def test_compute_col_stats_all_sequence_numerical_with_all_nan():
+def test_compute_col_stats_sequence_numerical_with_nan():
     ser = pd.Series([[np.nan, np.nan, np.nan, np.inf],
                      [np.nan, np.nan, np.nan]])
     stype = sequence_numerical
@@ -144,11 +145,20 @@ def test_compute_col_stats_numerical_with_nan():
     }
 
 
-def test_compute_col_stats_numerical_all_nan():
+def test_compute_col_stats_numerical_nan():
     ser = pd.Series([np.nan, np.nan, np.nan, np.nan])
     stype = numerical
     assert compute_col_stats(ser, stype) == {
         StatType.MEAN: np.nan,
         StatType.STD: np.nan,
         StatType.QUANTILES: [np.nan, np.nan, np.nan, np.nan, np.nan],
+    }
+
+
+def test_compute_col_stats_embedding():
+    emb_dim = 12
+    ser = pd.Series([np.random.rand(emb_dim) for _ in range(3)])
+    stype = embedding
+    assert compute_col_stats(ser, stype) == {
+        StatType.EMB_DIM: emb_dim,
     }

--- a/test/nn/encoder/test_stypewise_encoder.py
+++ b/test/nn/encoder/test_stypewise_encoder.py
@@ -11,6 +11,7 @@ from torch_frame.nn import (
     LinearEmbeddingEncoder,
     LinearEncoder,
     LinearModelEncoder,
+    LinearMultiEmbeddingEncoder,
     LinearPeriodicEncoder,
     MultiCategoricalEmbeddingEncoder,
     StypeWiseFeatureEncoder,
@@ -33,21 +34,31 @@ from torch_frame.testing.text_tokenizer import (
 @pytest.mark.parametrize('encoder_multicategorical_cls_kwargs', [
     (MultiCategoricalEmbeddingEncoder, {}),
 ])
-@pytest.mark.parametrize('encoder_text_embedded_cls_kwargs', [
-    (LinearEmbeddingEncoder, {}),
-])
+@pytest.mark.parametrize(
+    'encoder_text_embedded_cls_kwargs',
+    [
+        # TODO: Migrate to LinearMultiEmbeddingEncoder
+        (LinearEmbeddingEncoder, {}),
+    ])
 @pytest.mark.parametrize('encoder_text_tokenized_cls_kwargs', [
     (LinearModelEncoder, {
         'model': RandomTextModel(12, 2),
         'in_channels': 12,
     }),
 ])
+@pytest.mark.parametrize(
+    'encoder_embedding_cls_kwargs',
+    [
+        # TODO: Migrate to LinearMultiEmbeddingEncoder
+        (LinearMultiEmbeddingEncoder, {}),
+    ])
 def test_stypewise_feature_encoder(
     encoder_cat_cls_kwargs,
     encoder_num_cls_kwargs,
     encoder_multicategorical_cls_kwargs,
     encoder_text_embedded_cls_kwargs,
     encoder_text_tokenized_cls_kwargs,
+    encoder_embedding_cls_kwargs,
 ):
     num_rows = 10
     dataset: Dataset = FakeDataset(
@@ -59,6 +70,7 @@ def test_stypewise_feature_encoder(
             stype.multicategorical,
             stype.text_embedded,
             stype.text_tokenized,
+            stype.embedding,
         ],
         text_embedder_cfg=TextEmbedderConfig(
             text_embedder=HashTextEmbedder(out_channels=16, ),
@@ -91,6 +103,8 @@ def test_stypewise_feature_encoder(
             stype.text_tokenized:
             encoder_text_tokenized_cls_kwargs[0](
                 **encoder_text_tokenized_cls_kwargs[1]),
+            stype.embedding:
+            encoder_embedding_cls_kwargs[0](**encoder_embedding_cls_kwargs[1]),
         },
     )
     x, col_names = encoder(tensor_frame)
@@ -109,4 +123,6 @@ def test_stypewise_feature_encoder(
         "multicat_2",
         "multicat_3",
         "multicat_4",
+        "emb_1",
+        "emb_2",
     ]

--- a/torch_frame/data/stats.py
+++ b/torch_frame/data/stats.py
@@ -60,6 +60,9 @@ class StatType(Enum):
             torch_frame.timestamp: [
                 StatType.YEAR_RANGE,
             ],
+            torch_frame.embedding: [
+                StatType.EMB_DIM,
+            ]
         }
         return stats_type.get(stype, [])
 
@@ -110,6 +113,9 @@ class StatType(Enum):
             ser = pd.to_datetime(ser, format=time_format)
             year_range = ser.dt.year.values
             return [min(year_range), max(year_range)]
+
+        elif self == StatType.EMB_DIM:
+            return len(ser[0])
 
 
 _default_values = {

--- a/torch_frame/nn/encoder/__init__.py
+++ b/torch_frame/nn/encoder/__init__.py
@@ -10,6 +10,7 @@ from .stype_encoder import (
     LinearPeriodicEncoder,
     ExcelFormerEncoder,
     LinearEmbeddingEncoder,
+    LinearMultiEmbeddingEncoder,
     LinearModelEncoder,
     StackEncoder,
 )
@@ -25,6 +26,7 @@ __all__ = classes = [
     'LinearPeriodicEncoder',
     'ExcelFormerEncoder',
     'LinearEmbeddingEncoder',
+    'LinearMultiEmbeddingEncoder',
     'LinearModelEncoder',
     'StackEncoder',
 ]


### PR DESCRIPTION
We can migrate `stype_encoder` of `text_embedded` into `LinearMultiEmbeddingEncoder`.
Then, we can rename `LinearMultiEmbeddingEncoder` into `LinearEmbeddingEncoder`, so that both `embedding` and `text_embedded` stypes use `LinearEmbeddingEncoder`.