### PR TITLE
Add optional `col_names` argument in `StypeEncoder`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
+- Added optional `col_names` argument in `StypeEncoder` ([#247](https://github.com/pyg-team/pytorch-frame/pull/247))
 - Added `col_to_text_embedder_cfg` and use `MultiEmbeddingTensor` for `text_embedded` ([#246](https://github.com/pyg-team/pytorch-frame/pull/246))
 - Added `col_encoder_dict` in `StypeWiseFeatureEncoder` ([#244](https://github.com/pyg-team/pytorch-frame/pull/244))
 - Added `LinearEmbeddingEncoder` for `embedding` stype ([#243](https://github.com/pyg-team/pytorch-frame/pull/243))

--- a/test/nn/encoder/test_stype_encoder.py
+++ b/test/nn/encoder/test_stype_encoder.py
@@ -43,13 +43,14 @@ def test_categorical_feature_encoder(encoder_cls_kwargs):
         **encoder_cls_kwargs[1],
     )
     feat_cat = tensor_frame.feat_dict[stype.categorical]
-    x = encoder(feat_cat)
+    col_names = tensor_frame.col_names_dict[stype.categorical]
+    x = encoder(feat_cat, col_names)
     assert x.shape == (feat_cat.size(0), feat_cat.size(1), 8)
 
     # Perturb the first column
     num_categories = len(stats_list[0][StatType.COUNT])
     feat_cat[:, 0] = (feat_cat[:, 0] + 1) % num_categories
-    x_perturbed = encoder(feat_cat)
+    x_perturbed = encoder(feat_cat, col_names)
     # Make sure other column embeddings are unchanged
     assert (x_perturbed[:, 1:, :] == x[:, 1:, :]).all()
 
@@ -91,7 +92,8 @@ def test_numerical_feature_encoder(encoder_cls_kwargs):
                                     stype=stype.numerical,
                                     **encoder_cls_kwargs[1])
     feat_num = tensor_frame.feat_dict[stype.numerical]
-    x = encoder(feat_num)
+    col_names = tensor_frame.col_names_dict[stype.numerical]
+    x = encoder(feat_num, col_names)
     assert x.shape == (feat_num.size(0), feat_num.size(1), 8)
     if "post_module" in encoder_cls_kwargs[1]:
         assert encoder.post_module is not None
@@ -100,7 +102,7 @@ def test_numerical_feature_encoder(encoder_cls_kwargs):
 
     # Perturb the first column
     feat_num[:, 0] = feat_num[:, 0] + 10.0
-    x_perturbed = encoder(feat_num)
+    x_perturbed = encoder(feat_num, col_names)
     # Make sure other column embeddings are unchanged
     assert (x_perturbed[:, 1:, :] == x[:, 1:, :]).all()
 
@@ -136,14 +138,15 @@ def test_multicategorical_feature_encoder(encoder_cls_kwargs):
         **encoder_cls_kwargs[1],
     )
     feat_multicat = tensor_frame.feat_dict[stype.multicategorical]
-    x = encoder(feat_multicat)
+    col_names = tensor_frame.col_names_dict[stype.multicategorical]
+    x = encoder(feat_multicat, col_names)
     assert x.shape == (feat_multicat.size(0), feat_multicat.size(1), 8)
 
     # Perturb the first column
     num_categories = len(stats_list[0][StatType.MULTI_COUNT])
     feat_multicat[:,
                   0].values = (feat_multicat[:, 0].values + 1) % num_categories
-    x_perturbed = encoder(feat_multicat)
+    x_perturbed = encoder(feat_multicat, col_names)
     # Make sure other column embeddings are unchanged
     assert (x_perturbed[:, 1:, :] == x[:, 1:, :]).all()
 
@@ -169,8 +172,9 @@ def test_categorical_feature_encoder_with_nan(encoder_cls_kwargs):
         **encoder_cls_kwargs[1],
     )
     feat_cat = tensor_frame.feat_dict[stype.categorical]
+    col_names = tensor_frame.col_names_dict[stype.categorical]
     isnan_mask = feat_cat == -1
-    x = encoder(feat_cat)
+    x = encoder(feat_cat, col_names)
     assert x.shape == (feat_cat.size(0), feat_cat.size(1), 8)
     # Make sure there's no NaNs in x
     assert (~torch.isnan(x)).all()
@@ -198,8 +202,9 @@ def test_numerical_feature_encoder_with_nan(encoder_cls_kwargs):
                                     stype=stype.numerical,
                                     **encoder_cls_kwargs[1])
     feat_num = tensor_frame.feat_dict[stype.numerical]
+    col_names = tensor_frame.col_names_dict[stype.numerical]
     isnan_mask = feat_num.isnan()
-    x = encoder(feat_num)
+    x = encoder(feat_num, col_names)
     assert x.shape == (feat_num.size(0), feat_num.size(1), 8)
     # Make sure there's no NaNs in x
     assert (~torch.isnan(x)).all()
@@ -236,8 +241,9 @@ def test_multicategorical_feature_encoder_with_nan(encoder_cls_kwargs):
         **encoder_cls_kwargs[1],
     )
     feat_multicat = tensor_frame.feat_dict[stype.multicategorical]
+    col_names = tensor_frame.col_names_dict[stype.multicategorical]
     isnan_mask = feat_multicat.values == -1
-    x = encoder(feat_multicat)
+    x = encoder(feat_multicat, col_names)
     assert x.shape == (feat_multicat.size(0), feat_multicat.size(1), 8)
     # Make sure there's no NaNs in x
     assert (~torch.isnan(x)).all()
@@ -269,9 +275,10 @@ def test_text_embedded_encoder():
         stats_list=stats_list,
         stype=stype.text_embedded,
     )
-    x_text = tensor_frame.feat_dict[stype.text_embedded]
-    x = encoder(x_text)
-    assert x.shape == (
+    feat_text = tensor_frame.feat_dict[stype.text_embedded]
+    col_names = tensor_frame.col_names_dict[stype.text_embedded]
+    feat = encoder(feat_text, col_names)
+    assert feat.shape == (
         num_rows,
         len(tensor_frame.col_names_dict[stype.text_embedded]),
         out_channels,
@@ -298,8 +305,9 @@ def test_embedding_encoder():
         stats_list=stats_list,
         stype=stype.embedding,
     )
-    x_text = tensor_frame.feat_dict[stype.embedding]
-    x = encoder(x_text)
+    feat_text = tensor_frame.feat_dict[stype.embedding]
+    col_names = tensor_frame.col_names_dict[stype.embedding]
+    x = encoder(feat_text, col_names)
     assert x.shape == (
         num_rows,
         len(tensor_frame.col_names_dict[stype.embedding]),
@@ -340,8 +348,9 @@ def test_text_tokenized_encoder():
         in_channels=text_emb_channels,
         model=model,
     )
-    x_text = tensor_frame.feat_dict[stype.text_tokenized]
-    x = encoder(x_text)
+    feat_text = tensor_frame.feat_dict[stype.text_tokenized]
+    col_names = tensor_frame.col_names_dict[stype.text_tokenized]
+    x = encoder(feat_text, col_names)
     assert x.shape == (
         num_rows,
         len(tensor_frame.col_names_dict[stype.text_tokenized]),

--- a/torch_frame/nn/encoder/stypewise_encoder.py
+++ b/torch_frame/nn/encoder/stypewise_encoder.py
@@ -61,12 +61,13 @@ class StypeWiseFeatureEncoder(FeatureEncoder):
                 self.encoder_dict[stype.value] = stype_encoder
 
     def forward(self, tf: TensorFrame) -> Tuple[Tensor, List[str]]:
-        col_names = []
+        all_col_names = []
         xs = []
         for stype in tf.stypes:
             feat = tf.feat_dict[stype]
-            x = self.encoder_dict[stype.value](feat)
+            col_names = self.col_names_dict[stype]
+            x = self.encoder_dict[stype.value](feat, col_names)
             xs.append(x)
-            col_names.extend(self.col_names_dict[stype])
+            all_col_names.extend(col_names)
         x = torch.cat(xs, dim=1)
-        return x, col_names
+        return x, all_col_names


### PR DESCRIPTION
so that `StypeEncoder` can use the information of `col_names` when necessary. Useful for per-column text model for `text_tokenized`.