### PR TITLE
Add `--compile` option to examples

### DIFF
--- a/examples/excelformer.py
+++ b/examples/excelformer.py
@@ -31,12 +31,10 @@ parser.add_argument('--num_layers', type=int, default=5)
 parser.add_argument('--lr', type=float, default=0.001)
 parser.add_argument('--epochs', type=int, default=100)
 parser.add_argument('--mixup', type=bool, default=True)
+parser.add_argument('--compile', action='store_true')
 args = parser.parse_args()
 
-if torch.cuda.is_available():
-    device = torch.device('cuda')
-else:
-    device = torch.device('cpu')
+device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
 
 path = osp.join(osp.dirname(osp.realpath(__file__)), '..', 'data',
                 args.dataset)
@@ -90,6 +88,7 @@ model = ExcelFormer(
     col_stats=mutual_info_sort.transformed_stats,
     col_names_dict=train_tensor_frame.col_names_dict,
 ).to(device)
+model = torch.compile(model, dynamic=True) if args.compile else model
 optimizer = torch.optim.Adam(model.parameters(), lr=args.lr)
 lr_scheduler = ExponentialLR(optimizer, gamma=0.95)
 

--- a/examples/llm_embedding.py
+++ b/examples/llm_embedding.py
@@ -34,6 +34,7 @@ parser.add_argument(
 )
 parser.add_argument("--dataset", type=str, default="wine_reviews")
 parser.add_argument("--api_key", type=str, default=None)
+parser.add_argument('--compile', action='store_true')
 args = parser.parse_args()
 
 # Notice that there are 568,454 rows and 2 text columns, it will
@@ -169,6 +170,7 @@ model = FTTransformer(
     col_names_dict=train_dataset.tensor_frame.col_names_dict,
     stype_encoder_dict=stype_encoder_dict,
 ).to(device)
+model = torch.compile(model, dynamic=True) if args.compile else model
 
 optimizer = torch.optim.AdamW(model.parameters(), lr=args.lr)
 

--- a/examples/mercari.py
+++ b/examples/mercari.py
@@ -50,6 +50,7 @@ parser.add_argument("--batch_size", type=int, default=512)
 parser.add_argument("--lr", type=float, default=0.0001)
 parser.add_argument("--epochs", type=int, default=50)
 parser.add_argument("--seed", type=int, default=0)
+parser.add_argument("--compile", action="store_true")
 args = parser.parse_args()
 
 torch.manual_seed(args.seed)
@@ -102,7 +103,7 @@ model = FTTransformer(
     col_names_dict=train_tensor_frame.col_names_dict,
     stype_encoder_dict=stype_encoder_dict,
 ).to(device)
-
+model = torch.compile(model, dynamic=True) if args.compile else model
 optimizer = torch.optim.Adam(model.parameters(), lr=args.lr)
 lr_scheduler = ExponentialLR(optimizer, gamma=0.95)
 

--- a/examples/revisiting.py
+++ b/examples/revisiting.py
@@ -45,6 +45,7 @@ parser.add_argument('--batch_size', type=int, default=512)
 parser.add_argument('--lr', type=float, default=0.0001)
 parser.add_argument('--epochs', type=int, default=100)
 parser.add_argument('--seed', type=int, default=0)
+parser.add_argument('--compile', action='store_true')
 args = parser.parse_args()
 
 torch.manual_seed(args.seed)
@@ -108,6 +109,7 @@ elif args.model_type == 'resnet':
 else:
     raise ValueError(f'Unsupported model type: {args.model_type}')
 
+model = torch.compile(model, dynamic=True) if args.compile else model
 optimizer = torch.optim.AdamW(model.parameters(), lr=args.lr)
 
 

--- a/examples/tab_transformer.py
+++ b/examples/tab_transformer.py
@@ -32,6 +32,7 @@ parser.add_argument('--batch_size', type=int, default=128)
 parser.add_argument('--lr', type=float, default=0.0001)
 parser.add_argument('--epochs', type=int, default=100)
 parser.add_argument('--seed', type=int, default=0)
+parser.add_argument('--compile', action='store_true')
 args = parser.parse_args()
 
 torch.manual_seed(args.seed)
@@ -78,7 +79,7 @@ model = TabTransformer(
     col_stats=dataset.col_stats,
     col_names_dict=train_tensor_frame.col_names_dict,
 ).to(device)
-
+model = torch.compile(model, dynamic=True) if args.compile else model
 optimizer = torch.optim.Adam(model.parameters(), lr=args.lr)
 lr_scheduler = ExponentialLR(optimizer, gamma=0.95)
 

--- a/examples/tabnet.py
+++ b/examples/tabnet.py
@@ -27,6 +27,7 @@ parser.add_argument('--batch_size', type=int, default=4096)
 parser.add_argument('--lr', type=float, default=0.005)
 parser.add_argument('--epochs', type=int, default=50)
 parser.add_argument('--seed', type=int, default=0)
+parser.add_argument('--compile', action='store_true')
 args = parser.parse_args()
 
 torch.manual_seed(args.seed)
@@ -69,7 +70,7 @@ model = TabNet(
     col_stats=dataset.col_stats,
     col_names_dict=train_tensor_frame.col_names_dict,
 ).to(device)
-
+model = torch.compile(model, dynamic=True) if args.compile else model
 optimizer = torch.optim.Adam(model.parameters(), lr=args.lr)
 lr_scheduler = ExponentialLR(optimizer, gamma=0.95)
 

--- a/examples/transformers_text.py
+++ b/examples/transformers_text.py
@@ -78,6 +78,7 @@ parser.add_argument(
 )
 parser.add_argument("--pooling", type=str, default="mean",
                     choices=["mean", "cls"])
+parser.add_argument("--compile", action="store_true")
 args = parser.parse_args()
 
 if args.lora and not args.finetune:
@@ -262,7 +263,7 @@ model = FTTransformer(
     col_names_dict=train_tensor_frame.col_names_dict,
     stype_encoder_dict=stype_encoder_dict,
 ).to(device)
-
+model = torch.compile(model, dynamic=True) if args.compile else model
 optimizer = torch.optim.AdamW(model.parameters(), lr=args.lr)
 
 

--- a/examples/trompt.py
+++ b/examples/trompt.py
@@ -36,6 +36,7 @@ parser.add_argument("--batch_size", type=int, default=256)
 parser.add_argument("--lr", type=float, default=0.001)
 parser.add_argument("--epochs", type=int, default=50)
 parser.add_argument("--seed", type=int, default=0)
+parser.add_argument("--compile", action="store_true")
 args = parser.parse_args()
 
 torch.manual_seed(args.seed)
@@ -77,7 +78,7 @@ model = Trompt(
     col_stats=dataset.col_stats,
     col_names_dict=train_tensor_frame.col_names_dict,
 ).to(device)
-
+model = torch.compile(model, dynamic=True) if args.compile else model
 optimizer = torch.optim.Adam(model.parameters(), lr=args.lr)
 lr_scheduler = ExponentialLR(optimizer, gamma=0.95)
 

--- a/examples/tuned_gbdt.py
+++ b/examples/tuned_gbdt.py
@@ -41,8 +41,7 @@ parser.add_argument('--dataset', type=str, default='eye_movements')
 parser.add_argument('--seed', type=int, default=0)
 args = parser.parse_args()
 
-device = (torch.device('cuda')
-          if torch.cuda.is_available() else torch.device('cpu'))
+device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
 
 random.seed(args.seed)
 np.random.seed(args.seed)

--- a/test/nn/models/test_compile.py
+++ b/test/nn/models/test_compile.py
@@ -47,7 +47,7 @@ from torch_frame.testing import withPackage
                 ffn_dropout=0.5,
             ),
             None,
-            2,
+            4,
             id="TabTransformer",
         ),
         pytest.param(
@@ -61,7 +61,7 @@ from torch_frame.testing import withPackage
             ExcelFormer,
             dict(in_channels=8, num_cols=3, num_heads=1),
             [stype.numerical],
-            2,
+            4,
             id="ExcelFormer",
         ),
     ],

--- a/test/nn/models/test_compile.py
+++ b/test/nn/models/test_compile.py
@@ -73,6 +73,7 @@ def test_compile_graph_break(
     expected_graph_breaks,
 ):
     torch._dynamo.config.suppress_errors = True
+
     dataset = FakeDataset(
         num_rows=10,
         with_nan=False,

--- a/test/nn/models/test_compile.py
+++ b/test/nn/models/test_compile.py
@@ -72,6 +72,7 @@ def test_compile_graph_break(
     stypes,
     expected_graph_breaks,
 ):
+    torch._dynamo.config.suppress_errors = True
     dataset = FakeDataset(
         num_rows=10,
         with_nan=False,
@@ -87,4 +88,5 @@ def test_compile_graph_break(
         **model_kwargs,
     )
     explanation = torch._dynamo.explain(model)(tf)
+    print(explanation)
     assert explanation.graph_break_count <= expected_graph_breaks

--- a/test/nn/models/test_compile.py
+++ b/test/nn/models/test_compile.py
@@ -88,5 +88,4 @@ def test_compile_graph_break(
         **model_kwargs,
     )
     explanation = torch._dynamo.explain(model)(tf)
-    print(explanation)
     assert explanation.graph_break_count <= expected_graph_breaks

--- a/test/nn/models/test_compile.py
+++ b/test/nn/models/test_compile.py
@@ -47,7 +47,7 @@ from torch_frame.testing import withPackage
                 ffn_dropout=0.5,
             ),
             None,
-            4,
+            2,
             id="TabTransformer",
         ),
         pytest.param(
@@ -61,7 +61,7 @@ from torch_frame.testing import withPackage
             ExcelFormer,
             dict(in_channels=8, num_cols=3, num_heads=1),
             [stype.numerical],
-            4,
+            2,
             id="ExcelFormer",
         ),
     ],
@@ -72,8 +72,6 @@ def test_compile_graph_break(
     stypes,
     expected_graph_breaks,
 ):
-    torch._dynamo.config.suppress_errors = True
-
     dataset = FakeDataset(
         num_rows=10,
         with_nan=False,


### PR DESCRIPTION
This PR adds `--compile` option to examples.

I ran all of these examples with the default args. Some (e.g. `tabnet.py`) run faster while others run slower than eager, e.g., due to excessive recompilations.

Although most examples run without any error raised, there're two examples we need to investigate further for `torch.compile` support in the future:

1. `mercari.py` fails due to numerical accuracy issue (similarly to https://github.com/pytorch/pytorch/issues/114109)

```bash
$ python examples/mercari.py --compile
Traceback (most recent call last):
  File "/home/akihiro/work/github.com/pyg-team/pytorch-frame/examples/mercari.py", line 69, in <module>
    dataset.materialize(path=osp.join(path, "data.pt"))
  File "/home/akihiro/work/github.com/pyg-team/pytorch-frame/torch_frame/data/dataset.py", line 518, in materialize
    self._tensor_frame = self._to_tensor_frame_converter(self.df, device)
  File "/home/akihiro/work/github.com/pyg-team/pytorch-frame/torch_frame/data/dataset.py", line 246, in __call__
    out = self._get_mapper(col).forward(df[col], device=device)
  File "/home/akihiro/work/github.com/pyg-team/pytorch-frame/torch_frame/data/mapper.py", line 166, in forward
    ser = ser.apply(lambda row: MultiCategoricalTensorMapper.split_by_sep(
  File "/home/akihiro/.conda/envs/pyf310/lib/python3.10/site-packages/pandas/core/series.py", line 4760, in apply
    ).apply()
  File "/home/akihiro/.conda/envs/pyf310/lib/python3.10/site-packages/pandas/core/apply.py", line 1207, in apply
    return self.apply_standard()
  File "/home/akihiro/.conda/envs/pyf310/lib/python3.10/site-packages/pandas/core/apply.py", line 1287, in apply_standard
    mapped = obj._map_values(
  File "/home/akihiro/.conda/envs/pyf310/lib/python3.10/site-packages/pandas/core/base.py", line 921, in _map_values
    return algorithms.map_array(arr, mapper, na_action=na_action, convert=convert)
  File "/home/akihiro/.conda/envs/pyf310/lib/python3.10/site-packages/pandas/core/algorithms.py", line 1814, in map_array
    return lib.map_infer(values, mapper, convert=convert)
  File "lib.pyx", line 2920, in pandas._libs.lib.map_infer
  File "/home/akihiro/work/github.com/pyg-team/pytorch-frame/torch_frame/data/mapper.py", line 166, in <lambda>
    ser = ser.apply(lambda row: MultiCategoricalTensorMapper.split_by_sep(
  File "/home/akihiro/work/github.com/pyg-team/pytorch-frame/torch_frame/data/mapper.py", line 152, in split_by_sep
    raise ValueError(
ValueError: MulticategoricalTensorMapper only supports str or list types (got input: nan)
```

2. `tab_transformer.py` fails due to https://github.com/pytorch/pytorch/issues/111603
```bash
$ python examples/tab_transformer.py --compile
Epoch: 1:   0%|                                                                                                      | 0/230 [00:00<?, ?it/s]
/home/akihiro/.conda/envs/pyf310/lib/python3.10/site-packages/torch/overrides.py:110: UserWarning: 'has_cuda' is deprecated, please use 'torch.backends.cuda.is_built()'
  torch.has_cuda,
/home/akihiro/.conda/envs/pyf310/lib/python3.10/site-packages/torch/overrides.py:111: UserWarning: 'has_cudnn' is deprecated, please use 'torch.backends.cudnn.is_available()'
  torch.has_cudnn,
/home/akihiro/.conda/envs/pyf310/lib/python3.10/site-packages/torch/overrides.py:117: UserWarning: 'has_mps' is deprecated, please use 'torch.backends.mps.is_built()'
  torch.has_mps,
/home/akihiro/.conda/envs/pyf310/lib/python3.10/site-packages/torch/overrides.py:118: UserWarning: 'has_mkldnn' is deprecated, please use 'torch.backends.mkldnn.is_available()'
  torch.has_mkldnn,
Epoch: 1:   0%|▍                                                                                           | 1/230 [00:32<2:05:06, 32.78s/it]
ERROR RUNNING GUARDS forward /home/akihiro/work/github.com/pyg-team/pytorch-frame/torch_frame/nn/models/tab_transformer.py:133
lambda L, **___kwargs_ignored:
  ___guarded_code.valid and
  ___check_type_id(L['tf'], 94357325008832) and
  ___check_obj_id(L['self'], 140383307281168) and
  L['self'].training == True and
  ___check_type_id(L['tf'].feat_dict, 94357210918496) and
  set(L['tf'].feat_dict.keys()) == {L["stype"].categorical, L["stype"].numerical} and
  hasattr(L['tf'].feat_dict[L["stype"].numerical], '_dynamo_dynamic_indices') == False and
  hasattr(L['tf'].feat_dict[L["stype"].categorical], '_dynamo_dynamic_indices') == False and
  ___is_grad_enabled() and
  not ___are_deterministic_algorithms_enabled() and
  ___is_torch_function_enabled() and
  utils_device.CURRENT_DEVICE == None and
  ___check_obj_id(G['stype'].categorical, 140383339764688) and
  ___check_tensors(L['tf'].feat_dict[L["stype"].numerical], L['tf'].feat_dict[L["stype"].categorical], tensor_check_names=tensor_check_names) and
  L['tf'].feat_dict[L["stype"].numerical].stride()[0] == L['tf'].feat_dict[L["stype"].numerical].size()[1] and
  L['tf'].feat_dict[L["stype"].categorical].size()[0] == L['tf'].feat_dict[L["stype"].numerical].size()[0] and
  2 <= L['tf'].feat_dict[L["stype"].numerical].size()[0] and
  2 <= L['tf'].feat_dict[L["stype"].numerical].size()[1] and
  L['tf'].feat_dict[L["stype"].categorical].size()[0] == L['tf'].feat_dict[L["stype"].numerical].size()[0] and
  2 <= L['tf'].feat_dict[L["stype"].numerical].size()[0] and
  2 <= L['tf'].feat_dict[L["stype"].numerical].size()[1]
Epoch: 1:   0%|▍                                                                                           | 1/230 [00:32<2:05:07, 32.78s/it]
Traceback (most recent call last):
  File "/home/akihiro/work/github.com/pyg-team/pytorch-frame/examples/tab_transformer.py", line 127, in <module>
    train_loss = train(epoch)
  File "/home/akihiro/work/github.com/pyg-team/pytorch-frame/examples/tab_transformer.py", line 93, in train
    pred = model.forward(tf)
  File "/home/akihiro/.conda/envs/pyf310/lib/python3.10/site-packages/torch/_dynamo/eval_frame.py", line 328, in _fn
    return fn(*args, **kwargs)
  File "/home/akihiro/.conda/envs/pyf310/lib/python3.10/site-packages/torch/nn/modules/module.py", line 1518, in _wrapped_call_impl
    return self._call_impl(*args, **kwargs)
  File "/home/akihiro/.conda/envs/pyf310/lib/python3.10/site-packages/torch/nn/modules/module.py", line 1527, in _call_impl
    return forward_call(*args, **kwargs)
  File "<string>", line 16, in guard
KeyError: 'stype'
```

---

TODO in future PRs:
- Have some benchmark numbers
- Investigate these failures above