### PR TITLE
Add `mypy` as a type checker

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -62,3 +62,4 @@ repos:
     hooks:
       - id: mypy
         name: Check types
+        exclude: "docs|tests|benchmark|examples"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -56,3 +56,9 @@ repos:
       - id: ruff
         name: Ruff formatting
         args: [--fix, --exit-non-zero-on-fix]
+
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v1.7.1
+    hooks:
+      - id: mypy
+        name: Check types

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -62,4 +62,4 @@ repos:
     hooks:
       - id: mypy
         name: Check types
-        exclude: "docs|tests|benchmark|examples"
+        exclude: "^test/|^examples/|^benchmark/"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -99,6 +99,59 @@ skip = [".gitignore", "__init__.py"]
 [tool.flake8]
 ignore = ["F811", "W503", "W504"]
 
+[tool.mypy]
+files = ["torch_frame"]
+install_types = true
+non_interactive = true
+ignore_missing_imports = true
+show_error_codes = true
+warn_redundant_casts = true
+warn_unused_configs = true
+warn_unused_ignores = true
+
+# TODO: the goal is for this ignore list to be empty
+[[tool.mypy.overrides]]
+ignore_errors = true
+# Run this command to generate this list of files
+# mypy --no-error-summary 2>&1 | tr ':' ' ' | awk '{print $1}' | sort | uniq | sed 's/\.py//g; s|src/||g;  s|\/|\.|g' | xargs -I {} echo '"{}",'
+module = [
+    "torch_frame.data.dataset",
+    "torch_frame.data.loader",
+    "torch_frame.data.mapper",
+    "torch_frame.data.multi_embedding_tensor",
+    "torch_frame.data.multi_nested_tensor",
+    "torch_frame.data.multi_tensor",
+    "torch_frame.data.stats",
+    "torch_frame.data.tensor_frame",
+    "torch_frame.datasets.data_frame_benchmark",
+    "torch_frame.datasets.fake",
+    "torch_frame.datasets.kdd_census_income",
+    "torch_frame.datasets.mercari",
+    "torch_frame.datasets.tabular_benchmark",
+    "torch_frame.datasets.yandex",
+    "torch_frame.gbdt.gbdt",
+    "torch_frame.gbdt.tuned_catboost",
+    "torch_frame.gbdt.tuned_lightgbm",
+    "torch_frame.gbdt.tuned_xgboost",
+    "torch_frame.nn.conv.excelformer_conv",
+    "torch_frame.nn.encoder.stype_encoder",
+    "torch_frame.nn.encoder.stypewise_encoder",
+    "torch_frame.nn.models.excelformer",
+    "torch_frame.nn.models.ft_transformer",
+    "torch_frame.nn.models.resnet",
+    "torch_frame.nn.models.tab_transformer",
+    "torch_frame.nn.models.tabnet",
+    "torch_frame.nn.models.trompt",
+    "torch_frame.testing.text_tokenizer",
+    "torch_frame.transforms.base_transform",
+    "torch_frame.transforms.cat_to_num_transform",
+    "torch_frame.transforms.fittable_base_transform",
+    "torch_frame.transforms.mutual_information_sort",
+    "torch_frame.utils.concat",
+    "torch_frame.utils.infer_stype",
+    "torch_frame.utils.io",
+]
+
 [tool.pytest.ini_options]
 addopts = [
     "--capture=no",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -101,6 +101,10 @@ ignore = ["F811", "W503", "W504"]
 
 [tool.mypy]
 files = ["torch_frame"]
+exclude = [
+    "tests",
+    "examples",
+]
 install_types = true
 non_interactive = true
 ignore_missing_imports = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -101,10 +101,6 @@ ignore = ["F811", "W503", "W504"]
 
 [tool.mypy]
 files = ["torch_frame"]
-exclude = [
-    "tests",
-    "examples",
-]
 install_types = true
 non_interactive = true
 ignore_missing_imports = true


### PR DESCRIPTION
I'm in favor of adding mypy (or any other type checker) so that I don't have to guess how to correctly annotate PyF. Also, we no longer need to comment things like https://github.com/pyg-team/pytorch-frame/pull/258/files#r1412843422 as mypy will raise errors :)

### Usage
Run
```
pip install mypy
mypy  # automatically reads config in pyproject.toml
```
or via pre-commit
```
pip install pre-commit
pre-commit install
```