### PR TITLE
Drop mypy from pre-commit.ci and run mypy in a GHA workflow

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -1,0 +1,24 @@
+name: Linting
+
+on:  # yamllint disable-line rule:truthy
+  push:
+    branches:
+      - master
+  pull_request:
+
+jobs:
+  mypy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: 3.8
+      - name: Install dependencies
+        run: |
+          pip install mypy
+          pip install torch --index-url https://download.pytorch.org/whl/cpu
+      - name: Check type hints
+        run: mypy

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,6 +2,9 @@ ci:
   autofix_prs: true
   autoupdate_commit_msg: '[pre-commit.ci] pre-commit suggestions'
   autoupdate_schedule: quarterly
+  # mypy exceeds free tier 250MiB limit on pre-commit.ci
+  # https://github.com/pre-commit-ci/issues/issues/171
+  skip: [mypy]
 
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks


### PR DESCRIPTION
pre-commit.ci doesn't support having data more than 250MiB as seen in [this run](https://results.pre-commit.ci/run/github/677240069/1701948936.LN0QYu8HRtCf3o7UpKs6bQ):
```
Build of https://github.com/pre-commit/mirrors-mypy:torch==2.1.1@v1.7.1 for python@python3 exceeds tier max size 250MiB: 4.5GiB
```

This PR moves mypy from pre-commit.ci to GHA to unblock #276 and future PRs for type check in CI.

