### PR TITLE
Clean up `col_to_pattern` logic

### DIFF
--- a/test/data/test_dataset.py
+++ b/test/data/test_dataset.py
@@ -106,6 +106,7 @@ def test_converter():
         col_to_stype=dataset.col_to_stype,
         col_stats=dataset.col_stats,
         target_col=dataset.target_col,
+        col_to_sep=dataset.col_to_sep,
         col_to_time_format=dataset.col_to_time_format,
     )
     tf = convert_to_tensor_frame(dataset.df)
@@ -169,21 +170,45 @@ def test_canonicalize_col_to_pattern():
     assert {
         'col_1': '|',
         'col_2': '|'
-    } == canonicalize_col_to_pattern(col_to_sep, columns)
+    } == canonicalize_col_to_pattern(col_to_sep, columns,
+                                     requires_all_inclusive=True)
 
     col_to_sep = {'col_1': '|', 'col_2': ','}
     columns = ['col_1', 'col_2']
     assert {
         'col_1': '|',
         'col_2': ','
-    } == canonicalize_col_to_pattern(col_to_sep, columns)
+    } == canonicalize_col_to_pattern(col_to_sep, columns,
+                                     requires_all_inclusive=True)
 
     col_to_sep = {'col_1': '|'}
     columns = ['col_1', 'col_2']
     with pytest.raises(ValueError, match='col_to_sep needs to specify'):
-        canonicalize_col_to_pattern(col_to_sep, columns, all_inclusive=True)
+        canonicalize_col_to_pattern(col_to_sep, columns,
+                                    requires_all_inclusive=True)
 
     col_to_sep = {'col_1': '|'}
     columns = ['col_1', 'col_2']
-    assert col_to_sep == canonicalize_col_to_pattern(col_to_sep, columns,
-                                                     all_inclusive=False)
+    assert {
+        'col_1': '|',
+        'col_2': None
+    } == canonicalize_col_to_pattern(col_to_sep, columns,
+                                     requires_all_inclusive=False)
+
+
+def test_col_to_pattern_raise_error():
+    with pytest.raises(TypeError, match="col_to_sep"):
+        dataset = FakeDataset(num_rows=10, stypes=[stype.multicategorical])
+        Dataset(dataset.df, dataset.col_to_stype, dataset.target_col,
+                col_to_sep=2)
+
+    with pytest.raises(TypeError, match="col_to_text_embedder_cfg"):
+        FakeDataset(num_rows=10, stypes=[stype.text_embedded])
+
+    with pytest.raises(TypeError, match="col_to_text_tokenizer_cfg"):
+        FakeDataset(num_rows=10, stypes=[stype.text_tokenized])
+
+    with pytest.raises(TypeError, match="col_to_time_format"):
+        dataset = FakeDataset(num_rows=10, stypes=[stype.timestamp])
+        Dataset(dataset.df, dataset.col_to_stype, dataset.target_col,
+                col_to_time_format=2)

--- a/test/data/test_dataset.py
+++ b/test/data/test_dataset.py
@@ -170,7 +170,7 @@ def test_canonicalize_col_to_pattern():
     assert {
         'col_1': '|',
         'col_2': '|'
-    } == canonicalize_col_to_pattern(col_to_sep, columns,
+    } == canonicalize_col_to_pattern("col_to_sep", col_to_sep, columns,
                                      requires_all_inclusive=True)
 
     col_to_sep = {'col_1': '|', 'col_2': ','}
@@ -178,13 +178,13 @@ def test_canonicalize_col_to_pattern():
     assert {
         'col_1': '|',
         'col_2': ','
-    } == canonicalize_col_to_pattern(col_to_sep, columns,
+    } == canonicalize_col_to_pattern("col_to_sep", col_to_sep, columns,
                                      requires_all_inclusive=True)
 
     col_to_sep = {'col_1': '|'}
     columns = ['col_1', 'col_2']
-    with pytest.raises(ValueError, match='col_to_xxx requires all columns'):
-        canonicalize_col_to_pattern(col_to_sep, columns,
+    with pytest.raises(ValueError, match='col_to_sep requires all columns'):
+        canonicalize_col_to_pattern("col_to_sep", col_to_sep, columns,
                                     requires_all_inclusive=True)
 
     col_to_sep = {'col_1': '|'}
@@ -192,7 +192,7 @@ def test_canonicalize_col_to_pattern():
     assert {
         'col_1': '|',
         'col_2': None
-    } == canonicalize_col_to_pattern(col_to_sep, columns,
+    } == canonicalize_col_to_pattern("col_to_sep", col_to_sep, columns,
                                      requires_all_inclusive=False)
 
 

--- a/test/data/test_dataset.py
+++ b/test/data/test_dataset.py
@@ -183,7 +183,7 @@ def test_canonicalize_col_to_pattern():
 
     col_to_sep = {'col_1': '|'}
     columns = ['col_1', 'col_2']
-    with pytest.raises(ValueError, match='col_to_sep needs to specify'):
+    with pytest.raises(ValueError, match='col_to_xxx requires all columns'):
         canonicalize_col_to_pattern(col_to_sep, columns,
                                     requires_all_inclusive=True)
 

--- a/test/data/test_stats.py
+++ b/test/data/test_stats.py
@@ -43,16 +43,17 @@ def test_compute_col_stats_categorical():
 
 
 def test_compute_col_stats_multi_categorical():
-    for ser in [
-            pd.Series(['a|a|b', 'a|c', 'c|a', 'a|b|c', '', None, np.nan]),
+    for ser, sep in [
+        (pd.Series(['a|a|b', 'a|c', 'c|a', 'a|b|c', '', None, np.nan]), '|'),
             # # Testing with leading and traling whitespace
-            pd.Series(['a| a | b', 'a| c', 'c |a', '  a| b| c', '  ', None]),
+        (pd.Series(['a, a , b', 'a, c', 'c ,a', '  a, b, c', '  ',
+                    None]), ','),
             # Testing with list representation
-            pd.Series([['a', 'a', 'b'], ['a', 'c'], ['c', 'a'],
-                       ['a', 'b', 'c'], [], None]),
+        (pd.Series([['a', 'a', 'b'], ['a', 'c'], ['c', 'a'], ['a', 'b', 'c'],
+                    [], None]), None),
     ]:
         stype = multicategorical
-        assert compute_col_stats(ser, stype, sep='|') == {
+        assert compute_col_stats(ser, stype, sep=sep) == {
             StatType.MULTI_COUNT: (['a', 'c', 'b'], [4, 3, 2]),
         }
 

--- a/torch_frame/data/dataset.py
+++ b/torch_frame/data/dataset.py
@@ -191,7 +191,7 @@ class DataFrameToTensorFrameConverter:
             # in-place sorting of col_names for each stype
             self._col_names_dict[stype].sort()
 
-        # Assumed to be canonicalized already by dataset
+        # Assumed to be already canonicalized by Dataset
         self.col_to_sep = col_to_sep
         self.col_to_time_format = col_to_time_format
         self.col_to_text_embedder_cfg = col_to_text_embedder_cfg

--- a/torch_frame/data/dataset.py
+++ b/torch_frame/data/dataset.py
@@ -38,24 +38,24 @@ from torch_frame.typing import (
 from torch_frame.utils.split import SPLIT_TO_NUM
 
 COL_TO_PATTERN_STYPE_MAPPING = {
-    'col_to_sep': torch_frame.multicategorical,
-    'col_to_time_format': torch_frame.timestamp,
-    'col_to_text_embedder_cfg': torch_frame.text_embedded,
-    'col_to_text_tokenizer_cfg': torch_frame.text_tokenized,
+    "col_to_sep": torch_frame.multicategorical,
+    "col_to_time_format": torch_frame.timestamp,
+    "col_to_text_embedder_cfg": torch_frame.text_embedded,
+    "col_to_text_tokenizer_cfg": torch_frame.text_tokenized,
 }
 
 COL_TO_PATTERN_REQUIRED_TYPE_MAPPING = {
-    'col_to_sep': str,
-    'col_to_time_format': str,
-    'col_to_text_embedder_cfg': TextEmbedderConfig,
-    'col_to_text_tokenizer_cfg': TextTokenizerConfig,
+    "col_to_sep": str,
+    "col_to_time_format": str,
+    "col_to_text_embedder_cfg": TextEmbedderConfig,
+    "col_to_text_tokenizer_cfg": TextTokenizerConfig,
 }
 
 COL_TO_PATTERN_ALLOW_NONE_MAPPING = {
-    'col_to_sep': True,
-    'col_to_time_format': True,
-    'col_to_text_embedder_cfg': False,
-    'col_to_text_tokenizer_cfg': False,
+    "col_to_sep": True,
+    "col_to_time_format": True,
+    "col_to_text_embedder_cfg": False,
+    "col_to_text_tokenizer_cfg": False,
 }
 
 
@@ -370,16 +370,16 @@ class Dataset(ABC):
 
         # Canonicalize and validate
         self.col_to_sep = self.canonicalize_and_validate_col_to_pattern(
-            col_to_sep, 'col_to_sep')
+            col_to_sep, "col_to_sep")
         (self.col_to_time_format
          ) = self.canonicalize_and_validate_col_to_pattern(
-             col_to_time_format, 'col_to_time_format')
+             col_to_time_format, "col_to_time_format")
         (self.col_to_text_embedder_cfg
          ) = self.canonicalize_and_validate_col_to_pattern(
-             col_to_text_embedder_cfg, 'col_to_text_embedder_cfg')
+             col_to_text_embedder_cfg, "col_to_text_embedder_cfg")
         (self.col_to_text_tokenizer_cfg
          ) = self.canonicalize_and_validate_col_to_pattern(
-             col_to_text_tokenizer_cfg, 'col_to_text_tokenizer_cfg')
+             col_to_text_tokenizer_cfg, "col_to_text_tokenizer_cfg")
 
         self._is_materialized: bool = False
         self._col_stats: dict[str, dict[StatType, Any]] = {}

--- a/torch_frame/data/dataset.py
+++ b/torch_frame/data/dataset.py
@@ -140,7 +140,7 @@ class DataFrameToTensorFrameConverter:
             column name into stats. Available as :obj:`dataset.col_stats`.
         target_col (str, optional): The column used as target.
             (default: :obj:`None`)
-        col_to_sep (Dict[str, str]): A dictionary specifying the
+        col_to_sep (Dict[str, Optional[str]]): A dictionary specifying the
             separator/delimiter for the multi-categorical columns.
             (default: :obj:`{}`)
         col_to_text_embedder_cfg (Dict[str, TextEmbedderConfig]):
@@ -155,7 +155,7 @@ class DataFrameToTensorFrameConverter:
             keys are input arguments to the model such as :obj:`input_ids`, and
             values are tensors such as tokens. :obj:`batch_size` specifies the
             mini-batch size for :obj:`text_tokenizer`. (default: :obj:`{}`)
-        col_to_time_format (Dict[str, str]): A dictionary of the
+        col_to_time_format (Dict[str, Optional[str]]): A dictionary of the
             time format for the timestamp columns. See `strfttime documentation
             <https://docs.python.org/3/library/datetime.html#strftime-and-strptime-behavior>`_
             for more information on formats. If a string is specified,
@@ -285,11 +285,13 @@ class Dataset(ABC):
             information. The column should only contain :obj:`0`, :obj:`1`, or
             :obj:`2`. (default: :obj:`None`).
         col_to_sep (Union[str, Dict[str, Optional[str]]]): A dictionary or a
-            string specifying the separator/delimiter for the multi-categorical
-            columns. If a string is specified, then the same separator will
-            be used throughout all the multi-categorical columns. If a
-            dictionary is given, we use a separator specified for each
-            column. (default: :obj:`None`)
+            string/:obj:`None` specifying the separator/delimiter for the
+            multi-categorical columns. If a string/:obj:`None` is specified,
+            then the same separator will be used throughout all the
+            multi-categorical columns. Note that if :obj:`None` is specified,
+            it assumes a multi-category is given as a :obj:`list` of
+            categories. If a dictionary is given, we use a separator specified
+            for each column. (default: :obj:`None`)
         col_to_text_embedder_cfg (TextEmbedderConfig or dict, optional):
             A text embedder configuration or a dictionary of configurations
             specifying :obj:`text_embedder` that maps text columns into
@@ -321,12 +323,12 @@ class Dataset(ABC):
         col_to_stype: dict[str, torch_frame.stype],
         target_col: str | None = None,
         split_col: str | None = None,
-        col_to_sep: str | dict[str, str] | None = None,
+        col_to_sep: str | None | dict[str, str | None] = None,
         col_to_text_embedder_cfg: dict[str, TextEmbedderConfig]
         | TextEmbedderConfig | None = None,
         col_to_text_tokenizer_cfg: dict[str, TextTokenizerConfig]
         | TextTokenizerConfig | None = None,
-        col_to_time_format: str | dict[str, str] | None = None,
+        col_to_time_format: str | None | dict[str, str | None] = None,
     ):
         self.df = df
         self.target_col = target_col

--- a/torch_frame/data/dataset.py
+++ b/torch_frame/data/dataset.py
@@ -121,10 +121,8 @@ def canonicalize_col_to_pattern(
         if len(missing_cols) > 0:
             if requires_all_inclusive:
                 raise ValueError(
-                    "col_to_sep needs to specify separators for all "
-                    "multi-categorical columns, but the separators for the "
-                    "following columns are missing: "
-                    f"{list(missing_cols)}.")
+                    f"col_to_xxx requires all columns to be specified but the "
+                    f"following columns are missing: {list(missing_cols)}.")
             else:
                 for col in missing_cols:
                     col_to_pattern[col] = None

--- a/torch_frame/data/dataset.py
+++ b/torch_frame/data/dataset.py
@@ -5,7 +5,7 @@ import functools
 import os.path as osp
 from abc import ABC
 from collections import defaultdict
-from typing import Any
+from typing import Any, Dict
 
 import pandas as pd
 import torch
@@ -37,6 +37,27 @@ from torch_frame.typing import (
 )
 from torch_frame.utils.split import SPLIT_TO_NUM
 
+COL_TO_PATTERN_STYPE_MAPPING = {
+    'col_to_sep': torch_frame.multicategorical,
+    'col_to_time_format': torch_frame.timestamp,
+    'col_to_text_embedder_cfg': torch_frame.text_embedded,
+    'col_to_text_tokenizer_cfg': torch_frame.text_tokenized,
+}
+
+COL_TO_PATTERN_REQUIRED_TYPE_MAPPING = {
+    'col_to_sep': str,
+    'col_to_time_format': str,
+    'col_to_text_embedder_cfg': TextEmbedderConfig,
+    'col_to_text_tokenizer_cfg': TextTokenizerConfig,
+}
+
+COL_TO_PATTERN_ALLOW_NONE_MAPPING = {
+    'col_to_sep': True,
+    'col_to_time_format': True,
+    'col_to_text_embedder_cfg': False,
+    'col_to_text_tokenizer_cfg': False,
+}
+
 
 def requires_pre_materialization(func):
     @functools.wraps(func)
@@ -62,9 +83,11 @@ def requires_post_materialization(func):
     return _requires_post_materialization
 
 
-def canonicalize_col_to_pattern(col_to_pattern: Any | dict[str, Any] | None,
-                                columns: list[str],
-                                all_inclusive: bool = True) -> dict[str, Any]:
+def canonicalize_col_to_pattern(
+    col_to_pattern: Any | dict[str, Any] | None,
+    columns: list[str],
+    requires_all_inclusive,
+) -> dict[str, Any]:
     r"""Canonicalize :obj:`col_to_pattern` into a dictionary format.
 
     Args:
@@ -77,8 +100,11 @@ def canonicalize_col_to_pattern(col_to_pattern: Any | dict[str, Any] | None,
             dictionary specified for each column.
         columns (List[str]): A list of multi-categorical, timestamp or text
             columns.
-        all_inclusive (bool): A boolean indicating whether all columns need
-            to be specified.(default: True)
+        requires_all_inclusive (bool): Whether all columns need to be specified
+            in :obj:`col_to_pattern` or not. If :obj:`True`, it will error out
+            when any of :obj:`columns` is not included in
+            :obj:`col_to_pattern`. If :obj:`False`, it automatically fill in
+            :obj:`None` to columns that are not in :obj:`col_to_pattern`.
 
     Returns:
         Dict[str, Any]: :obj:`col_to_pattern` in a dictionary format, mapping
@@ -91,13 +117,17 @@ def canonicalize_col_to_pattern(col_to_pattern: Any | dict[str, Any] | None,
         for col in columns:
             col_to_pattern[col] = pattern
     else:
-        if all_inclusive and len(set(columns) -
-                                 set(col_to_pattern.keys())) > 0:
-            raise ValueError(
-                "col_to_sep needs to specify separators for all "
-                "multi-categorical columns, but the separators for the "
-                "following columns are missing: "
-                f"{list(set(columns) - set(col_to_pattern.keys()))}.")
+        missing_cols = set(columns) - set(col_to_pattern.keys())
+        if len(missing_cols) > 0:
+            if requires_all_inclusive:
+                raise ValueError(
+                    "col_to_sep needs to specify separators for all "
+                    "multi-categorical columns, but the separators for the "
+                    "following columns are missing: "
+                    f"{list(missing_cols)}.")
+            else:
+                for col in missing_cols:
+                    col_to_pattern[col] = None
     return col_to_pattern
 
 
@@ -112,53 +142,44 @@ class DataFrameToTensorFrameConverter:
             column name into stats. Available as :obj:`dataset.col_stats`.
         target_col (str, optional): The column used as target.
             (default: :obj:`None`)
-        col_to_sep (Union[str, Dict[str, str]]): A dictionary or a string
-            specifying the separator/delimiter for the multi-categorical
-            columns. If a string is specified, then the same separator will
-            be used throughout all the multi-categorical columns. If a
-            dictionary is given, we use a separator specified for each
-            column. (default: :obj:`,`)
-        col_to_text_embedder_cfg (TextEmbedderConfig or dict, optional):
-            A text embedder configuration or a dictionary of configurations
-            specifying :obj:`text_embedder` that maps text columns into
-            :class:`torch.nn.Embeddings` and :obj:`batch_size` that
-            specifies the mini-batch size for :obj:`text_embedder`.
-            (default: :obj:`None`)
-        col_to_text_tokenizer_cfg (TextTokenizerConfig or dict, optional):
-            A text tokenizer configuration or dictionary of configurations
-            specifying :obj:`text_tokenizer` that maps sentences into a
-            list of dictionary of tensors. Each element in the list
-            corresponds to each sentence, keys are input arguments to
-            the model such as :obj:`input_ids`, and values are tensors
-            such as tokens. :obj:`batch_size` specifies the mini-batch
-            size for :obj:`text_tokenizer`. (default: :obj:`None`)
-        col_to_time_format (Union[str, Dict[str, str]], optional): A
-            dictionary or a string specifying the format for the timestamp
-            columns. See `strfttime documentation
+        col_to_sep (Dict[str, str]): A dictionary specifying the
+            separator/delimiter for the multi-categorical columns.
+            (default: :obj:`{}`)
+        col_to_text_embedder_cfg (Dict[str, TextEmbedderConfig]):
+            A dictionary of configurations specifying :obj:`text_embedder` that
+            maps text columns into :class:`torch.nn.Embeddings` and
+            :obj:`batch_size` that specifies the mini-batch size for
+            :obj:`text_embedder`. (default: :obj:`{}`)
+        col_to_text_tokenizer_cfg (Dict[str, TextTokenizerConfig]):
+            A dictionary of text tokenizer configurations, specifying
+            :obj:`text_tokenizer` that maps sentences into a list of dictionary
+            of tensors. Each element in the list corresponds to each sentence,
+            keys are input arguments to the model such as :obj:`input_ids`, and
+            values are tensors such as tokens. :obj:`batch_size` specifies the
+            mini-batch size for :obj:`text_tokenizer`. (default: :obj:`{}`)
+        col_to_time_format (Dict[str, str]): A dictionary of the
+            time format for the timestamp columns. See `strfttime documentation
             <https://docs.python.org/3/library/datetime.html#strftime-and-strptime-behavior>`_
             for more information on formats. If a string is specified,
             then the same format will be used throughout all the timestamp
             columns. If a dictionary is given, we use a different format
             specified for each column. If not specified, Pandas' internal
             to_datetime function will be used to auto parse time columns.
-            (default: None)
+            (default: :obj:`{}`)
     """
     def __init__(
         self,
         col_to_stype: dict[str, torch_frame.stype],
         col_stats: dict[str, dict[StatType, Any]],
         target_col: str | None = None,
-        col_to_sep: str | dict[str, str] = ",",
-        col_to_text_embedder_cfg: None |
-        (dict[str, TextEmbedderConfig] | TextEmbedderConfig) = None,
-        col_to_text_tokenizer_cfg: None |
-        (dict[str, TextTokenizerConfig] | TextTokenizerConfig) = None,
-        col_to_time_format: str | dict[str, str] | None = None,
+        col_to_sep: dict[str, str | None] = {},
+        col_to_text_embedder_cfg: dict[str, TextEmbedderConfig] = {},
+        col_to_text_tokenizer_cfg: dict[str, TextTokenizerConfig] = {},
+        col_to_time_format: dict[str, str | None] = {},
     ):
         self.col_to_stype = col_to_stype
         self.col_stats = col_stats
         self.target_col = target_col
-        self.col_to_text_tokenizer_cfg = col_to_text_tokenizer_cfg
 
         # Pre-compute a canonical `col_names_dict` for tensor frame.
         self._col_names_dict: dict[torch_frame.stype, list[str]] = {}
@@ -172,37 +193,11 @@ class DataFrameToTensorFrameConverter:
             # in-place sorting of col_names for each stype
             self._col_names_dict[stype].sort()
 
-        # Some multicategorical columns can be lists and thus
-        # do not need a separator.
-        self.col_to_sep = canonicalize_col_to_pattern(
-            col_to_sep,
-            self.col_names_dict.get(torch_frame.multicategorical),
-            all_inclusive=False,
-        )
-
-        self.col_to_time_format = canonicalize_col_to_pattern(
-            col_to_time_format,
-            self.col_names_dict.get(torch_frame.timestamp, []),
-            all_inclusive=False,
-        )
-
-        self.col_to_text_embedder_cfg = canonicalize_col_to_pattern(
-            col_to_text_embedder_cfg,
-            self.col_names_dict.get(torch_frame.text_embedded, []),
-        )
-
-        if (torch_frame.text_embedded in self.col_names_dict) \
-                and (self.col_to_text_embedder_cfg is None):
-            raise ValueError("`col_to_text_embedder_cfg` needs to be"
-                             "specified when stype.text_embedded column "
-                             "exists.")
-
-        if (torch_frame.text_tokenized
-                in self.col_names_dict) and (self.col_to_text_tokenizer_cfg
-                                             is None):
-            raise ValueError("`col_to_text_tokenizer_cfg` needs to be "
-                             "specified when stype.text_tokenized column "
-                             "exists.")
+        # Assumed to be canonicalized already by dataset
+        self.col_to_sep = col_to_sep
+        self.col_to_time_format = col_to_time_format
+        self.col_to_text_embedder_cfg = col_to_text_embedder_cfg
+        self.col_to_text_tokenizer_cfg = col_to_text_tokenizer_cfg
 
     @property
     def col_names_dict(self) -> dict[torch_frame.stype, list[str]]:
@@ -218,11 +213,10 @@ class DataFrameToTensorFrameConverter:
             return CategoricalTensorMapper(index)
         elif stype == torch_frame.multicategorical:
             index, _ = self.col_stats[col][StatType.MULTI_COUNT]
-            return MultiCategoricalTensorMapper(
-                index, sep=self.col_to_sep.get(col, None))
+            return MultiCategoricalTensorMapper(index,
+                                                sep=self.col_to_sep[col])
         elif stype == torch_frame.timestamp:
-            return TimestampTensorMapper(
-                format=self.col_to_time_format.get(col, None))
+            return TimestampTensorMapper(format=self.col_to_time_format[col])
         elif stype == torch_frame.text_embedded:
             text_embedder_cfg = self.col_to_text_embedder_cfg[col]
             return TextEmbeddingTensorMapper(
@@ -292,13 +286,12 @@ class Dataset(ABC):
         split_col (str, optional): The column that stores the pre-defined split
             information. The column should only contain :obj:`0`, :obj:`1`, or
             :obj:`2`. (default: :obj:`None`).
-        col_to_sep (Union[str, Dict[str, str]]): A dictionary or a string
-            specifying the separator/delimiter for the multi-categorical
+        col_to_sep (Union[str, Dict[str, Optional[str]]]): A dictionary or a
+            string specifying the separator/delimiter for the multi-categorical
             columns. If a string is specified, then the same separator will
             be used throughout all the multi-categorical columns. If a
             dictionary is given, we use a separator specified for each
-            column. (default: :obj:`,`)
-            (default: :obj:`,`)
+            column. (default: :obj:`None`)
         col_to_text_embedder_cfg (TextEmbedderConfig or dict, optional):
             A text embedder configuration or a dictionary of configurations
             specifying :obj:`text_embedder` that maps text columns into
@@ -313,7 +306,7 @@ class Dataset(ABC):
             the model such as :obj:`input_ids`, and values are tensors
             such as tokens. :obj:`batch_size` specifies the mini-batch
             size for :obj:`text_tokenizer`. (default: :obj:`None`)
-        col_to_time_format (Union[str, Dict[str, str]], optional): A
+        col_to_time_format (Union[str, Dict[str, Optional[str]]], optional): A
             dictionary or a string specifying the format for the timestamp
             columns. See `strfttime documentation
             <https://docs.python.org/3/library/datetime.html#strftime-and-strptime-behavior>`_
@@ -322,7 +315,7 @@ class Dataset(ABC):
             columns. If a dictionary is given, we use a different format
             specified for each column. If not specified, pandas's internal
             to_datetime function will be used to auto parse time columns.
-            (default: None)
+            (default: :obj:`None`)
     """
     def __init__(
         self,
@@ -330,7 +323,7 @@ class Dataset(ABC):
         col_to_stype: dict[str, torch_frame.stype],
         target_col: str | None = None,
         split_col: str | None = None,
-        col_to_sep: str | dict[str, str] = ",",
+        col_to_sep: str | dict[str, str] | None = None,
         col_to_text_embedder_cfg: dict[str, TextEmbedderConfig]
         | TextEmbedderConfig | None = None,
         col_to_text_tokenizer_cfg: dict[str, TextTokenizerConfig]
@@ -367,32 +360,59 @@ class Dataset(ABC):
             raise ValueError(
                 "Multilabel classification task is not yet supported.")
 
-        self.col_to_sep = canonicalize_col_to_pattern(col_to_sep, [
-            col for col, stype in self.col_to_stype.items()
-            if stype == torch_frame.multicategorical
-        ], all_inclusive=False)
-        self.col_to_time_format = canonicalize_col_to_pattern(
-            col_to_time_format, [
-                col for col, stype in self.col_to_stype.items()
-                if stype == torch_frame.timestamp
-            ], all_inclusive=False)
-        self.col_to_text_embedder_cfg = canonicalize_col_to_pattern(
-            col_to_text_embedder_cfg,
-            [
-                col for col, stype in self.col_to_stype.items()
-                if stype == torch_frame.text_embedded
-            ],
-        )
-        self.col_to_text_tokenizer_cfg = canonicalize_col_to_pattern(
-            col_to_text_tokenizer_cfg,
-            [
-                col for col, stype in self.col_to_stype.items()
-                if stype == torch_frame.text_tokenized
-            ],
-        )
+        # Canonicalize and validate
+        self.col_to_sep = self.canonicalize_and_validate_col_to_pattern(
+            col_to_sep, 'col_to_sep')
+        (self.col_to_time_format
+         ) = self.canonicalize_and_validate_col_to_pattern(
+             col_to_time_format, 'col_to_time_format')
+        (self.col_to_text_embedder_cfg
+         ) = self.canonicalize_and_validate_col_to_pattern(
+             col_to_text_embedder_cfg, 'col_to_text_embedder_cfg')
+        (self.col_to_text_tokenizer_cfg
+         ) = self.canonicalize_and_validate_col_to_pattern(
+             col_to_text_tokenizer_cfg, 'col_to_text_tokenizer_cfg')
+
         self._is_materialized: bool = False
         self._col_stats: dict[str, dict[StatType, Any]] = {}
         self._tensor_frame: TensorFrame | None = None
+
+    def canonicalize_and_validate_col_to_pattern(
+        self,
+        col_to_pattern: Any,
+        col_to_pattern_name: str,
+    ) -> Dict[str, Any]:
+        canonical_col_to_pattern = canonicalize_col_to_pattern(
+            col_to_pattern=col_to_pattern,
+            columns=[
+                col for col, stype in self.col_to_stype.items()
+                if stype == COL_TO_PATTERN_STYPE_MAPPING[col_to_pattern_name]
+            ],
+            requires_all_inclusive=not COL_TO_PATTERN_ALLOW_NONE_MAPPING[
+                col_to_pattern_name],
+        )
+        assert isinstance(canonical_col_to_pattern, dict)
+
+        # Validate types of values.
+        for col, pattern in canonical_col_to_pattern.items():
+            pass_validation = False
+            required_type = COL_TO_PATTERN_REQUIRED_TYPE_MAPPING[
+                col_to_pattern_name]
+            allow_none = COL_TO_PATTERN_ALLOW_NONE_MAPPING[col_to_pattern_name]
+            if isinstance(pattern, required_type):
+                pass_validation = True
+            if allow_none and pattern is None:
+                pass_validation = True
+
+            if not pass_validation:
+                msg = f"{col_to_pattern_name}[{col}] must be of type "
+                msg += str(required_type)
+                if allow_none:
+                    msg += " or None"
+                msg += f", but {pattern} given."
+                raise TypeError(msg)
+
+        return canonical_col_to_pattern
 
     @staticmethod
     def download_url(

--- a/torch_frame/data/dataset.py
+++ b/torch_frame/data/dataset.py
@@ -92,8 +92,9 @@ def canonicalize_col_to_pattern(
     r"""Canonicalize :obj:`col_to_pattern` into a dictionary format.
 
     Args:
-        col_to_pattern_name (str): The name of :obj:`col_to_xxx` to
-            canonicalize.
+        col_to_pattern_name (str): The name of :obj:`col_to_pattern` function
+            in the string format. For instance, :obj:`"col_to_sep"` and
+            :obj:`"col_to_time_format"`.
         col_to_pattern (Union[Any, Dict[str, Any]]): A dictionary or an object
             specifying the separator/pattern/configuration for the
             multi-categorical, timestamp or text columns. If an object is

--- a/torch_frame/data/mapper.py
+++ b/torch_frame/data/mapper.py
@@ -123,13 +123,14 @@ class MultiCategoricalTensorMapper(TensorMapper):
     Args:
         categories (List[Any]): A list of possible categories in the
         multi-categorical column sorted by counts.
-        sep (str): The delimiter for the categories in each cell.
-        (default: :obj:`,`)
+        sep (str, optional): The delimiter for the categories in each cell.
+            If :obj:`None`, it assumes each cell is directly represented as a
+            list of categories. (default: :obj:`None`)
     """
     def __init__(
         self,
         categories: list[Any],
-        sep: str = ',',
+        sep: None | str = None,
     ):
         super().__init__()
         self.categories = categories
@@ -141,15 +142,17 @@ class MultiCategoricalTensorMapper(TensorMapper):
         self.index = pd.concat((self.index, (pd.Series([-1], index=[-1]))))
 
     @staticmethod
-    def split_by_sep(row: str | list[Any] | None, sep: str) -> set[Any]:
+    def split_by_sep(row: str | list[Any] | None, sep: None | str) -> set[Any]:
         if row is None or row is np.nan:
             return {-1}
         elif isinstance(row, str):
+            assert sep is not None
             if row.strip() == '':
                 return set()
             else:
                 return {cat.strip() for cat in row.split(sep)}
         elif isinstance(row, list):
+            assert sep is None
             return set(row)
         else:
             raise ValueError(

--- a/torch_frame/data/stats.py
+++ b/torch_frame/data/stats.py
@@ -114,9 +114,8 @@ class StatType(Enum):
             return count.index.tolist(), count.values.tolist()
 
         elif self == StatType.MULTI_COUNT:
-            if sep is not None:
-                ser = ser.apply(lambda row: MultiCategoricalTensorMapper.
-                                split_by_sep(row, sep))
+            ser = ser.apply(lambda row: MultiCategoricalTensorMapper.
+                            split_by_sep(row, sep))
             ser = ser.explode().dropna()
             count = ser.value_counts(ascending=False)
             return count.index.tolist(), count.values.tolist()

--- a/torch_frame/datasets/fake.py
+++ b/torch_frame/datasets/fake.py
@@ -197,6 +197,10 @@ class FakeDataset(torch_frame.data.Dataset):
             col_to_stype,
             target_col='target',
             split_col='split' if create_split else None,
+            col_to_sep={
+                'multicat_1': ',',
+                'multicat_2': ',',
+            },
             col_to_text_embedder_cfg=col_to_text_embedder_cfg,
             col_to_text_tokenizer_cfg=col_to_text_tokenizer_cfg,
             col_to_time_format={


### PR DESCRIPTION
- Remove redundancy, increase code sharing.
- Explicitly let `sep=None` handle `list` cell in multicategorical columns
- More type checking of canonicalized `col_to_pattern` to raise informative errors.