### PR TITLE
Make `target_column` optional in `DataFrameToTensorFrameConverter`

### DIFF
--- a/test/data/test_dataset.py
+++ b/test/data/test_dataset.py
@@ -112,6 +112,13 @@ def test_converter():
     tf = convert_to_tensor_frame(dataset.df)
     assert tf.col_names_dict == convert_to_tensor_frame.col_names_dict
     assert len(tf) == len(dataset)
+    assert tf.y is not None
+
+    df_without_target = dataset.df.drop(dataset.target_col, axis=1)
+    tf_without_target = convert_to_tensor_frame(df_without_target)
+    assert tf.col_names_dict == convert_to_tensor_frame.col_names_dict
+    assert len(tf) == len(dataset)
+    assert tf_without_target.y is None
 
 
 def test_multicategorical_materialization():

--- a/torch_frame/data/dataset.py
+++ b/torch_frame/data/dataset.py
@@ -274,7 +274,7 @@ class DataFrameToTensorFrameConverter:
                 feat_dict[stype] = torch.stack(xs, dim=1)
 
         y: Tensor | None = None
-        if self.target_col is not None:
+        if self.target_col is not None and self.target_col in df:
             y = self._get_mapper(self.target_col).forward(
                 df[self.target_col], device=device)
 


### PR DESCRIPTION
so that we can transform `DataFrame` without a target column at BP/test stage.