### PR TITLE
Allow `y=None` in `predict()` of `GBDT`

### DIFF
--- a/test/gbdt/test_gbdt.py
+++ b/test/gbdt/test_gbdt.py
@@ -72,10 +72,12 @@ def test_gbdt_with_save_load(gbdt_cls, stypes, task_type_and_metric):
 
     pred = gbdt.predict(tf_test=dataset.tensor_frame)
     score = gbdt.compute_metric(dataset.tensor_frame.y, pred)
-    loaded_pred = loaded_gbdt.predict(tf_test=dataset.tensor_frame)
-    loaded_score = loaded_gbdt.compute_metric(dataset.tensor_frame.y, pred)
 
-    assert torch.allclose(pred, loaded_pred, atol=1e-2)
+    loaded_score = loaded_gbdt.compute_metric(dataset.tensor_frame.y, pred)
+    dataset.tensor_frame.y = None
+    loaded_pred = loaded_gbdt.predict(tf_test=dataset.tensor_frame)
+
+    assert torch.allclose(pred, loaded_pred, atol=1e-5)
     assert gbdt.metric == metric
     assert score == loaded_score
     if task_type == TaskType.REGRESSION:

--- a/torch_frame/gbdt/tuned_catboost.py
+++ b/torch_frame/gbdt/tuned_catboost.py
@@ -202,10 +202,12 @@ class CatBoost(GBDT):
                                          num_boost_round), num_trials)
         self.params.update(study.best_params)
         train_x, train_y, cat_features = self._to_catboost_input(tf_train)
-        eval_x, eval_y, _ = self._to_catboost_input(tf_val)
+        val_x, val_y, _ = self._to_catboost_input(tf_val)
+        assert train_y is not None
+        assert val_y is not None
         self.model = catboost.CatBoost(self.params)
         self.model.fit(train_x, train_y, cat_features=cat_features,
-                       eval_set=[(eval_x, eval_y)], early_stopping_rounds=50,
+                       eval_set=[(val_x, val_y)], early_stopping_rounds=50,
                        logging_level="Silent")
 
     def _predict(self, tf_test: TensorFrame) -> Tensor:

--- a/torch_frame/gbdt/tuned_catboost.py
+++ b/torch_frame/gbdt/tuned_catboost.py
@@ -33,8 +33,8 @@ class CatBoost(GBDT):
                 concatenating tensors of categorical and numerical features of
                 the input :class:`TensorFrame`.
             y (numpy.ndarray, optional): Prediction label.
-            cat_features (np.ndarray): Array containing indexes of categorical
-                features.
+            cat_features (numpy.ndarray): Array containing indexes of
+                categorical features.
         """
         tf = tf.cpu()
         y = tf.y
@@ -123,12 +123,12 @@ class CatBoost(GBDT):
 
         Args:
             trial (optuna.trial.Trial): Optuna trial object.
-            train_x (np.ndarray): Train data.
-            train_y (np.ndarray): Train label.
-            val_x (np.ndarray): Validation data.
-            val_y (np.ndarray): Validation label.
-            cat_features (np.ndarray): Array containing indexes of categorical
-                features.
+            train_x (numpy.ndarray): Train data.
+            train_y (numpy.ndarray): Train label.
+            val_x (numpy.ndarray): Validation data.
+            val_y (numpy.ndarray): Validation label.
+            cat_features (numpy.ndarray): Array containing indexes of
+                categorical features.
             num_boost_round (int): Number of boosting round.
 
         Returns:

--- a/torch_frame/gbdt/tuned_catboost.py
+++ b/torch_frame/gbdt/tuned_catboost.py
@@ -39,7 +39,7 @@ class CatBoost(GBDT):
         tf = tf.cpu()
         y = tf.y
         if y is not None:
-            y = y.numpy()
+            y: np.ndarray = y.numpy()
 
         dfs: list[DataFrame] = []
         cat_features: list[np.ndarray] = []

--- a/torch_frame/gbdt/tuned_catboost.py
+++ b/torch_frame/gbdt/tuned_catboost.py
@@ -111,10 +111,10 @@ class CatBoost(GBDT):
 
     def objective(
         self,
-        trial: Any,
-        train_x: np.ndarray,
+        trial: Any,  # optuna.trial.Trial
+        train_x: DataFrame,
         train_y: np.ndarray,
-        val_x: np.ndarray,
+        val_x: DataFrame,
         val_y: np.ndarray,
         cat_features: np.ndarray,
         num_boost_round: int,
@@ -123,9 +123,9 @@ class CatBoost(GBDT):
 
         Args:
             trial (optuna.trial.Trial): Optuna trial object.
-            train_x (numpy.ndarray): Train data.
+            train_x (DataFrame): Train data.
             train_y (numpy.ndarray): Train label.
-            val_x (numpy.ndarray): Validation data.
+            val_x (DataFrame): Validation data.
             val_y (numpy.ndarray): Validation label.
             cat_features (numpy.ndarray): Array containing indexes of
                 categorical features.
@@ -204,15 +204,9 @@ class CatBoost(GBDT):
         assert train_y is not None
         assert val_y is not None
         study.optimize(
-            lambda trial: self.objective(
-                trial,
-                train_x,
-                train_y,
-                val_x,
-                val_y,
-                cat_features,
-                num_boost_round,
-            ), num_trials)
+            lambda trial: self.objective(trial, train_x, train_y, val_x, val_y,
+                                         cat_features, num_boost_round),
+            num_trials)
         self.params.update(study.best_params)
 
         self.model = catboost.CatBoost(self.params)

--- a/torch_frame/gbdt/tuned_lightgbm.py
+++ b/torch_frame/gbdt/tuned_lightgbm.py
@@ -161,8 +161,8 @@ class LightGBM(GBDT):
         elif self.task_type == TaskType.MULTICLASS_CLASSIFICATION:
             self.params["objective"] = "multiclass"
             self.params["metric"] = "multi_error"
-            self.params[
-                "num_class"] = self._num_classes or train_data.label.nunique()
+            self.params["num_class"] = self._num_classes or len(
+                np.unique(train_data.label))
         else:
             raise ValueError(f"{self.__class__.__name__} is not supported for "
                              f"{self.task_type}.")

--- a/torch_frame/gbdt/tuned_lightgbm.py
+++ b/torch_frame/gbdt/tuned_lightgbm.py
@@ -32,7 +32,7 @@ class LightGBM(GBDT):
                 numerical and categorical features of the input
                 :class:`TensorFrame`.
             y (numpy.ndarray, optional): Prediction label.
-            cat_features (numpy.ndarray): Array containing indexes of
+            cat_features (list[int]): Array containing indexes of
                 categorical features.
         """
         tf = tf.cpu()
@@ -41,14 +41,14 @@ class LightGBM(GBDT):
             y: np.ndarray = y.numpy()
 
         dfs: list[DataFrame] = []
-        cat_features: list[np.ndarray] = []
+        cat_features_list: list[np.ndarray] = []
         offset: int = 0
 
         if stype.categorical in tf.feat_dict:
             feat = tf.feat_dict[stype.categorical].numpy()
             arange = np.arange(offset, offset + feat.shape[1])
             dfs.append(pd.DataFrame(feat, columns=arange))
-            cat_features.append(arange)
+            cat_features_list.append(arange)
             offset += feat.shape[1]
 
         if stype.numerical in tf.feat_dict:
@@ -71,8 +71,9 @@ class LightGBM(GBDT):
             raise ValueError("The input TensorFrame object is empty.")
 
         df = pd.concat(dfs, axis=1)
-        cat_features = np.concatenate(
-            cat_features, axis=0).tolist() if len(cat_features) else []
+        cat_features: list[int] = np.concatenate(
+            cat_features_list,
+            axis=0).tolist() if len(cat_features_list) else []
 
         return df, y, cat_features
 
@@ -102,7 +103,7 @@ class LightGBM(GBDT):
         trial: Any,  # optuna.trial.Trial
         train_data: Any,  # lightgbm.Dataset
         eval_data: Any,  # lightgbm.Dataset
-        cat_features: np.ndarray,
+        cat_features: list[int],
         num_boost_round: int,
     ) -> float:
         r"""Objective function to be optimized.
@@ -111,7 +112,7 @@ class LightGBM(GBDT):
             trial (optuna.trial.Trial): Optuna trial object.
             train_data (lightgbm.Dataset): Train data.
             eval_data (lightgbm.Dataset): Validation data.
-            cat_features (numpy.ndarray): Array containing indexes of
+            cat_features (list[int]): Array containing indexes of
                 categorical features.
             num_boost_round (int): Number of boosting round.
 

--- a/torch_frame/gbdt/tuned_lightgbm.py
+++ b/torch_frame/gbdt/tuned_lightgbm.py
@@ -89,7 +89,7 @@ class LightGBM(GBDT):
             x (DataFrame): The input `DataFrame`.
 
         Returns:
-            pred (np.ndarray): The prediction output.
+            pred (numpy.ndarray): The prediction output.
         """
         pred = model.predict(x)
         if self.task_type == TaskType.MULTICLASS_CLASSIFICATION:

--- a/torch_frame/gbdt/tuned_lightgbm.py
+++ b/torch_frame/gbdt/tuned_lightgbm.py
@@ -203,9 +203,11 @@ class LightGBM(GBDT):
         self.params.update(study.best_params)
 
         train_x, train_y, cat_features = self._to_lightgbm_input(tf_train)
-        eval_x, eval_y, _ = self._to_lightgbm_input(tf_val)
+        val_x, val_y, _ = self._to_lightgbm_input(tf_val)
+        assert train_y is not None
+        assert val_y is not None
         train_data = lightgbm.Dataset(train_x, label=train_y)
-        eval_data = lightgbm.Dataset(eval_x, label=eval_y)
+        eval_data = lightgbm.Dataset(val_x, label=val_y)
         self.model = lightgbm.train(
             self.params, train_data, num_boost_round=num_boost_round,
             categorical_feature=cat_features, valid_sets=[eval_data],

--- a/torch_frame/gbdt/tuned_lightgbm.py
+++ b/torch_frame/gbdt/tuned_lightgbm.py
@@ -31,14 +31,14 @@ class LightGBM(GBDT):
             df (DataFrame): :obj:`DataFrame` that concatenates tensors of
                 numerical and categorical features of the input
                 :class:`TensorFrame`.
-            y (numpy.ndarray): Prediction target :obj:`numpy.ndarray`.
+            y (numpy.ndarray, optional): Prediction label.
             cat_features (numpy.ndarray): Array containing indexes of
                 categorical features.
         """
         tf = tf.cpu()
         y = tf.y
         if y is not None:
-            y = y.numpy()
+            y: np.ndarray = y.numpy()
 
         dfs: list[DataFrame] = []
         cat_features: list[np.ndarray] = []

--- a/torch_frame/gbdt/tuned_lightgbm.py
+++ b/torch_frame/gbdt/tuned_lightgbm.py
@@ -99,12 +99,12 @@ class LightGBM(GBDT):
 
     def objective(
         self,
-        trial: Any,
-        train_data: Any,
-        eval_data: Any,
+        trial: Any,  # optuna.trial.Trial
+        train_data: Any,  # lightgbm.Dataset
+        eval_data: Any,  # lightgbm.Dataset
         cat_features: np.ndarray,
         num_boost_round: int,
-    ):
+    ) -> float:
         r"""Objective function to be optimized.
 
         Args:

--- a/torch_frame/gbdt/tuned_xgboost.py
+++ b/torch_frame/gbdt/tuned_xgboost.py
@@ -58,7 +58,7 @@ class XGBoost(GBDT):
         tf = tf.cpu()
         y = tf.y
         if y is not None:
-            y = y.numpy()
+            y: np.ndarray = y.numpy()
 
         feats: list[Tensor] = []
         types: list[str] = []

--- a/torch_frame/gbdt/tuned_xgboost.py
+++ b/torch_frame/gbdt/tuned_xgboost.py
@@ -37,7 +37,7 @@ class XGBoost(GBDT):
     def _to_xgboost_input(
         self,
         tf: TensorFrame,
-    ) -> tuple[np.ndarray, np.ndarray, list[str]]:
+    ) -> tuple[np.ndarray, np.ndarray | None, list[str]]:
         r"""Convert :class:`TensorFrame` into XGBoost-compatible input format:
         :obj:`(feat, y, feat_types)`.
 
@@ -48,7 +48,7 @@ class XGBoost(GBDT):
             feat (numpy.ndarray): Output :obj:`numpy.ndarray` by
                 concatenating tensors of numerical and categorical features of
                 the input :class:`TensorFrame`.
-            y (numpy.ndarray): Prediction target :obj:`numpy.ndarray`.
+            y (numpy.ndarray, optional): Prediction target.
             feature_types (List[str]): List of feature types: "q" for numerical
                 features and "c" for categorical features. The abbreviation
                 aligns with xgboost tutorial.
@@ -57,7 +57,8 @@ class XGBoost(GBDT):
         """
         tf = tf.cpu()
         y = tf.y
-        assert y is not None
+        if y is not None:
+            y = y.numpy()
 
         feats: list[Tensor] = []
         types: list[str] = []
@@ -82,9 +83,9 @@ class XGBoost(GBDT):
         if len(feats) == 0:
             raise ValueError("The input TensorFrame object is empty.")
 
-        feat = torch.cat(feats, dim=-1)
+        feat = torch.cat(feats, dim=-1).numpy()
 
-        return feat.numpy(), y.numpy(), types
+        return feat, y, types
 
     def objective(
         self,
@@ -197,6 +198,8 @@ class XGBoost(GBDT):
             study = optuna.create_study(direction="maximize")
         train_feat, train_y, train_feat_type = self._to_xgboost_input(tf_train)
         val_feat, val_y, val_feat_type = self._to_xgboost_input(tf_val)
+        assert train_y is not None
+        assert val_y is not None
         dtrain = xgboost.DMatrix(train_feat, label=train_y,
                                  feature_types=train_feat_type,
                                  enable_categorical=True)


### PR DESCRIPTION
- At BP stage, we should not force users to supply `y` in TensorFrame.
- Also cache input to avoid redundant computation from tensor frame in every objective call.