### PR TITLE
Fix examples

### DIFF
--- a/examples/mercari.py
+++ b/examples/mercari.py
@@ -71,8 +71,8 @@ dataset.materialize(path=osp.join(path, "data.pt"))
 
 is_classification = dataset.task_type.is_classification
 
-# Use the pre-defined split if num_rows is not specified:
-if dataset.num_rows is None:
+# Use the pre-defined split when using the entire dataset
+if dataset.num_rows == 4943260:
     train_dataset, val_dataset, test_dataset = dataset.split()
 else:
     train_dataset = dataset[:0.8]

--- a/examples/mercari.py
+++ b/examples/mercari.py
@@ -78,8 +78,6 @@ else:
     train_dataset = dataset[:0.8]
     val_dataset = dataset[0.8:0.9]
     test_dataset = dataset[0.9:]
-if len(val_dataset) == 0:
-    train_dataset, val_dataset = train_dataset[:0.9], train_dataset[0.9:]
 
 # Set up data loaders
 train_tensor_frame = train_dataset.tensor_frame

--- a/examples/mercari.py
+++ b/examples/mercari.py
@@ -71,7 +71,13 @@ dataset.materialize(path=osp.join(path, "data.pt"))
 
 is_classification = dataset.task_type.is_classification
 
-train_dataset, val_dataset, test_dataset = dataset.split()
+# Use the pre-defined split if num_rows is not specified:
+if dataset.num_rows is None:
+    train_dataset, val_dataset, test_dataset = dataset.split()
+else:
+    train_dataset = dataset[:0.8]
+    val_dataset = dataset[0.8:0.9]
+    test_dataset = dataset[0.9:]
 if len(val_dataset) == 0:
     train_dataset, val_dataset = train_dataset[:0.9], train_dataset[0.9:]
 

--- a/examples/mercari.py
+++ b/examples/mercari.py
@@ -72,7 +72,7 @@ dataset.materialize(path=osp.join(path, "data.pt"))
 is_classification = dataset.task_type.is_classification
 
 # Use the pre-defined split when using the entire dataset
-if dataset.num_rows == 4943260:
+if dataset.num_rows == 4_943_260:
     train_dataset, val_dataset, test_dataset = dataset.split()
 else:
     train_dataset = dataset[:0.8]

--- a/examples/transformers_text.py
+++ b/examples/transformers_text.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import argparse
 import os.path as osp
 from typing import List


### PR DESCRIPTION
- Fixes #293
- Fixes `transformers_text.py` in Python 3.9 or before

IMO, this PR doesn't require a changelog entry.