### PR TITLE
Update docs

### DIFF
--- a/docs/source/get_started/introduction.rst
+++ b/docs/source/get_started/introduction.rst
@@ -24,6 +24,9 @@ of all datasets are available in :doc:`/modules/datasets`
 Initializing datasets is straightforward in :pyf:`PyTorch Frame`.
 An initialization of a dataset will automatically download its raw files and process the columns.
 
+In the below example, we will use one of the pre-loaded datasets, containing the Titanic passengers.
+If you would like to use your own dataset, refer to the example in :doc:`/handling_advanced_stypes/handle_heterogeneous_stypes`.
+
 .. code-block:: python
 
     from torch_frame.datasets import Titanic

--- a/docs/source/handling_advanced_stypes/handle_text.rst
+++ b/docs/source/handling_advanced_stypes/handle_text.rst
@@ -187,7 +187,7 @@ text_tokenized: Finetuning Text Models
 
 In contrast to :class:`stype.text_embedded<torch_frame.stype>`,
 :class:`stype.text_tokenized<torch_frame.stype>` does minimal processing at the dataset materialization stage
-by only tokenizing raw texts, i.e., transoforming strings into sequences of integers.
+by only tokenizing raw texts, i.e., transforming strings into sequences of integers.
 Then, during the training stage, the fully-fledged text models take the tokenized sentences as input
 and output text embeddings, which allows the text models to be trained in an end-to-end manner.
 


### PR DESCRIPTION
A few minor changes for docs clarity. From the doc reading, there is currently no way to use both embedded and tokenised text in the same table? I.e. to embed one text column, but tokenise a different one?