### PR TITLE
Fix `TimestampEncoder` not using `CyclicEncoding` for cyclic features

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 ### Removed
 
 ### Fixed
+- Fixed `TimestampEncoder` not applying `CyclicEncoder` to cyclic features ([#311](https://github.com/pyg-team/pytorch-frame/pull/311))
 - Fixed NaN masking in `multicateogrical` stype ([#307](https://github.com/pyg-team/pytorch-frame/pull/307))
 
 ## [0.2.0] - 2023-12-15

--- a/torch_frame/nn/encoder/stype_encoder.py
+++ b/torch_frame/nn/encoder/stype_encoder.py
@@ -873,7 +873,7 @@ class TimestampEncoder(StypeEncoder):
         # [batch_size, num_cols, num_time_feats, out_size]
         x = torch.cat([
             self.positional_encoding(feat_year),
-            self.positional_encoding(feat_rest)
+            self.cyclic_encoding(feat_rest)
         ], dim=2)
         # [batch_size, num_cols, num_time_feats, out_size] *
         # [num_cols, num_time_feats, out_size, out_channels]


### PR DESCRIPTION
See title.