### PR TITLE
missing norm_2 in excel_former

### DIFF
--- a/torch_frame/nn/conv/excelformer_conv.py
+++ b/torch_frame/nn/conv/excelformer_conv.py
@@ -158,6 +158,6 @@ class ExcelFormerConv(TableConv):
         x_residual = self.DiaM(x)
         x = F.dropout(x_residual, self.residual_dropout, self.training) + x
         x_residual = self.norm_2(x)
-        x_residual = self.AiuM(x)
+        x_residual = self.AiuM(x_residual)
         x = F.dropout(x_residual, self.residual_dropout, self.training) + x
         return x


### PR DESCRIPTION
I guess norm_2 was not being used in ExcelFormer. 