### PR TITLE
Better User Experience: fix reference issue in Dataset

### DIFF
--- a/torch_frame/data/dataset.py
+++ b/torch_frame/data/dataset.py
@@ -382,7 +382,7 @@ class Dataset(ABC):
                     f"split_col must only contain {set(SPLIT_TO_NUM.values())}"
                 )
         self.split_col = split_col
-        self.col_to_stype = col_to_stype
+        self.col_to_stype = col_to_stype.copy()
 
         cols = self.feat_cols + ([] if target_col is None else [target_col])
         missing_cols = set(cols) - set(df.columns)


### PR DESCRIPTION
If we don't do a `copy` here. Users might change `col_to_stype` after declaring the `Dataset` class and before calling `dataset.materialize()`. This will cause an error because user might add new keys to `col_to_stype`.

Example code snippet that hit this issue:
```
text_encoder = TextToEmbedding(model="sentence-transformers/paraphrase-multilingual-MiniLM-L12-v2",
                                device=device)
col_to_stype={'Surname': text_embedded, 'CreditScore':numerical,
              'Geography': categorical, 'Age': numerical,
              'Tenure': numerical, 'Balance': numerical, 
              'NumOfProducts': numerical,'HasCrCard': categorical,
              'IsActiveMember': categorical,'EstimatedSalary': numerical}
test_dataset = Dataset(df=pd.read_csv('/kaggle/input/playground-series-s4e1/test.csv'),
                        col_to_stype=col_to_stype,
                        col_to_text_embedder_cfg=TextEmbedderConfig(text_embedder=text_encoder, batch_size=32))
col_to_stype['Exited'] = categorical
train_dataset = Dataset(df=pd.read_csv('/kaggle/input/playground-series-s4e1/train.csv'),
                        col_to_stype=col_to_stype,
                        target_col='Exited',
                        col_to_text_embedder_cfg=TextEmbedderConfig(text_embedder=text_encoder, batch_size=32))

```