### PR TITLE
Support empty `TensorFrame({}, {})`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ venv/*
 *.out
 data/**
 catboost_info/
+.mypy_cache

--- a/.gitignore
+++ b/.gitignore
@@ -18,4 +18,3 @@ venv/*
 *.out
 data/**
 catboost_info/
-.mypy_cache

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ### Added
 - Added support for empty `TensorFrame` ([#339](https://github.com/pyg-team/pytorch-frame/pull/339))
-- Added support more stypes in `LinearModelEncoder` ([#325](https://github.com/pyg-team/pytorch-frame/pull/325))
+- Added support for more stypes in `LinearModelEncoder` ([#325](https://github.com/pyg-team/pytorch-frame/pull/325))
 - Added `stype_encoder_dict` to some models ([#319](https://github.com/pyg-team/pytorch-frame/pull/319))
 - Added `HuggingFaceDatasetDict` ([#287](https://github.com/pyg-team/pytorch-frame/pull/287))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 ## [Unreleased]
 
 ### Added
-- Support more stypes in `LinearModelEncoder` ([#325](https://github.com/pyg-team/pytorch-frame/pull/325))
+- Added support for empty `TensorFrame` ([#339](https://github.com/pyg-team/pytorch-frame/pull/339))
+- Added support more stypes in `LinearModelEncoder` ([#325](https://github.com/pyg-team/pytorch-frame/pull/325))
 - Added `stype_encoder_dict` to some models ([#319](https://github.com/pyg-team/pytorch-frame/pull/319))
-
 - Added `HuggingFaceDatasetDict` ([#287](https://github.com/pyg-team/pytorch-frame/pull/287))
 
 ### Changed

--- a/test/data/test_tensor_frame.py
+++ b/test/data/test_tensor_frame.py
@@ -11,7 +11,21 @@ from torch_frame.data.multi_nested_tensor import MultiNestedTensor
 
 def test_tensor_frame_basics(get_fake_tensor_frame):
     tf = get_fake_tensor_frame(num_rows=10)
+    assert tf.is_empty is False
+    assert tf.device == torch.device("cpu")
     assert tf.num_rows == len(tf) == 10
+    assert tf.num_cols == 16
+    # The order is guaranteed to be the same as that of stype definitions in
+    # the stype enum even though `feat_dict` has a different order.
+    assert tf.stypes == [
+        torch_frame.numerical,
+        torch_frame.categorical,
+        torch_frame.text_embedded,
+        torch_frame.text_tokenized,
+        torch_frame.multicategorical,
+        torch_frame.sequence_numerical,
+        torch_frame.embedding,
+    ]
     assert str(tf) == (
         "TensorFrame(\n"
         "  num_cols=16,\n"
@@ -29,15 +43,17 @@ def test_tensor_frame_basics(get_fake_tensor_frame):
         ")")
 
     tf = TensorFrame({}, {})
+    assert tf.is_empty is True
+    assert tf.device is None
     assert tf.num_rows == len(tf) == 0
     assert tf.num_cols == 0
-    assert str(tf) == (
-        "TensorFrame(\n"
-        "  num_cols=0,\n"
-        "  num_rows=0,\n"
-        "  has_target=False,\n"
-        "  device=None,\n"
-        ")")
+    assert tf.stypes == []
+    assert str(tf) == ("TensorFrame(\n"
+                       "  num_cols=0,\n"
+                       "  num_rows=0,\n"
+                       "  has_target=False,\n"
+                       "  device=None,\n"
+                       ")")
 
 
 def test_tensor_frame_error():
@@ -151,6 +167,12 @@ def test_equal_tensor_frame(get_fake_tensor_frame):
     tf2 = get_fake_tensor_frame(num_rows=11)
     assert tf1 != tf2
     assert tf2 != tf1
+
+    # Test empty TensorFrames
+    tf1 = TensorFrame({}, {})
+    tf2 = TensorFrame({}, {})
+    assert tf1 == tf2
+    assert tf2 == tf1
 
 
 def test_get_col_feat(get_fake_tensor_frame):

--- a/test/data/test_tensor_frame.py
+++ b/test/data/test_tensor_frame.py
@@ -28,6 +28,17 @@ def test_tensor_frame_basics(get_fake_tensor_frame):
         "  device='cpu',\n"
         ")")
 
+    tf = TensorFrame({}, {})
+    assert tf.num_rows == len(tf) == 0
+    assert tf.num_cols == 0
+    assert str(tf) == (
+        "TensorFrame(\n"
+        "  num_cols=0,\n"
+        "  num_rows=0,\n"
+        "  has_target=False,\n"
+        "  device=None,\n"
+        ")")
+
 
 def test_tensor_frame_error():
     feat_dict = {

--- a/torch_frame/data/tensor_frame.py
+++ b/torch_frame/data/tensor_frame.py
@@ -274,7 +274,7 @@ class TensorFrame:
         return (f"{self.__class__.__name__}(\n"
                 f"  num_cols={self.num_cols},\n"
                 f"  num_rows={self.num_rows},\n"
-                (f"{stype_repr}")
+                f"{stype_repr}"
                 f"  has_target={self.y is not None},\n"
                 f"  device='{self.device}',\n"
                 f")")

--- a/torch_frame/data/tensor_frame.py
+++ b/torch_frame/data/tensor_frame.py
@@ -184,10 +184,10 @@ class TensorFrame:
         return len(feat)
 
     @property
-    def device(self) -> torch.device:
+    def device(self) -> torch.device | None:
         r"""The device of the :class:`TensorFrame`."""
         if self.is_empty:
-            raise RuntimeError("Cannot get device of an empty TensorFrame.")
+            raise None
         feat = next(iter(self.feat_dict.values()))
         if isinstance(feat, dict):
             return next(iter(feat.values())).device
@@ -264,19 +264,21 @@ class TensorFrame:
     def __repr__(self) -> str:
         stype_repr: str
         if self.is_empty:
+            stype_repr = ""
+            device_repr = "  device=None,\n"
+        else:
             stype_repr = "\n".join([
                 f"  {stype.value} ({len(col_names)}): {col_names},"
                 for stype, col_names in self.col_names_dict.items()
             ])
             stype_repr += "\n"
-        else:
-            stype_repr = ""
+            device_repr = f"  device='{self.device}',\n"
         return (f"{self.__class__.__name__}(\n"
                 f"  num_cols={self.num_cols},\n"
                 f"  num_rows={self.num_rows},\n"
                 f"{stype_repr}"
                 f"  has_target={self.y is not None},\n"
-                f"  device='{self.device}',\n"
+                f"{device_repr}"
                 f")")
 
     def __getitem__(self, index: IndexSelectType) -> TensorFrame:

--- a/torch_frame/data/tensor_frame.py
+++ b/torch_frame/data/tensor_frame.py
@@ -187,7 +187,7 @@ class TensorFrame:
     def device(self) -> torch.device | None:
         r"""The device of the :class:`TensorFrame`."""
         if self.is_empty:
-            raise None
+            return None
         feat = next(iter(self.feat_dict.values()))
         if isinstance(feat, dict):
             return next(iter(feat.values())).device

--- a/torch_frame/data/tensor_frame.py
+++ b/torch_frame/data/tensor_frame.py
@@ -84,9 +84,6 @@ class TensorFrame:
 
     def validate(self) -> None:
         r"""Validates the :class:`TensorFrame` object."""
-        if len(self.feat_dict) == 0:
-            raise ValueError("feat_dict should not be empty.")
-
         if self.feat_dict.keys() != self.col_names_dict.keys():
             raise ValueError(
                 f"The keys of feat_dict and col_names_dict must be the same, "
@@ -179,6 +176,8 @@ class TensorFrame:
     @property
     def num_rows(self) -> int:
         r"""The number of rows in the :class:`TensorFrame`."""
+        if self.is_empty:
+            return 0
         feat = next(iter(self.feat_dict.values()))
         if isinstance(feat, dict):
             return len(next(iter(feat.values())))
@@ -186,10 +185,18 @@ class TensorFrame:
 
     @property
     def device(self) -> torch.device:
+        r"""The device of the :class:`TensorFrame`."""
+        if self.is_empty:
+            raise RuntimeError("Cannot get device of an empty TensorFrame.")
         feat = next(iter(self.feat_dict.values()))
         if isinstance(feat, dict):
             return next(iter(feat.values())).device
         return feat.device
+
+    @property
+    def is_empty(self) -> bool:
+        r"""Returns :obj:`True` if the :class:`TensorFrame` is empty."""
+        return len(self.feat_dict) == 0
 
     # Python Built-ins ########################################################
 
@@ -255,15 +262,19 @@ class TensorFrame:
         return not self.__eq__(other)
 
     def __repr__(self) -> str:
-        stype_repr = "\n".join([
-            f"  {stype.value} ({len(col_names)}): {col_names},"
-            for stype, col_names in self.col_names_dict.items()
-        ])
-
+        stype_repr: str
+        if self.is_empty:
+            stype_repr = "\n".join([
+                f"  {stype.value} ({len(col_names)}): {col_names},"
+                for stype, col_names in self.col_names_dict.items()
+            ])
+            stype_repr += "\n"
+        else:
+            stype_repr = ""
         return (f"{self.__class__.__name__}(\n"
                 f"  num_cols={self.num_cols},\n"
                 f"  num_rows={self.num_rows},\n"
-                f"{stype_repr}\n"
+                (f"{stype_repr}")
                 f"  has_target={self.y is not None},\n"
                 f"  device='{self.device}',\n"
                 f")")


### PR DESCRIPTION
This PR adds support for empty `TensorFrame` similarly to `pandas.DataFrame`.