### PR TITLE
Allow `str` as a key of `TensorFrame`

### DIFF
--- a/torch_frame/_stype.py
+++ b/torch_frame/_stype.py
@@ -82,6 +82,9 @@ class stype(Enum):
         else:
             return self
 
+    def __str__(self) -> str:
+        return f'{self.name}'
+
 
 numerical = stype('numerical')
 categorical = stype('categorical')

--- a/torch_frame/data/tensor_frame.py
+++ b/torch_frame/data/tensor_frame.py
@@ -268,7 +268,7 @@ class TensorFrame:
             device_repr = "  device=None,\n"
         else:
             stype_repr = "\n".join([
-                f"  {stype.value} ({len(col_names)}): {col_names},"
+                f"  {stype} ({len(col_names)}): {col_names},"
                 for stype, col_names in self.col_names_dict.items()
             ])
             stype_repr += "\n"


### PR DESCRIPTION
```diff
>>> import torch_frame
>>> torch_frame.numerical, str(torch_frame.numerical), f"{torch_frame.numerical}"
- (<stype.numerical: 'numerical'>, 'stype.numerical', 'stype.numerical')
+ (<stype.numerical: 'numerical'>, 'numerical', 'numerical')
```