### PR TITLE
Avoid shadowing task type in text benchmark

### DIFF
--- a/benchmark/data_frame_text_benchmark.py
+++ b/benchmark/data_frame_text_benchmark.py
@@ -7,7 +7,9 @@ import os.path as osp
 from typing import Any
 
 import torch
-from peft import LoraConfig, TaskType as peftTaskType, get_peft_model
+from peft import LoraConfig
+from peft import TaskType as peftTaskType
+from peft import get_peft_model
 from torch import Tensor
 from torch.nn import BCEWithLogitsLoss, CrossEntropyLoss, Module, MSELoss
 from torch.optim.lr_scheduler import ExponentialLR

--- a/benchmark/data_frame_text_benchmark.py
+++ b/benchmark/data_frame_text_benchmark.py
@@ -7,7 +7,7 @@ import os.path as osp
 from typing import Any
 
 import torch
-from peft import LoraConfig, TaskType, get_peft_model
+from peft import LoraConfig, TaskType as peftTaskType, get_peft_model
 from torch import Tensor
 from torch.nn import BCEWithLogitsLoss, CrossEntropyLoss, Module, MSELoss
 from torch.optim.lr_scheduler import ExponentialLR
@@ -135,7 +135,7 @@ class TextToEmbeddingFinetune(torch.nn.Module):
                              f"LoRA finetuning.")
 
         peft_config = LoraConfig(
-            task_type=TaskType.FEATURE_EXTRACTION,
+            task_type=peftTaskType.FEATURE_EXTRACTION,
             r=32,
             lora_alpha=32,
             inference_mode=False,


### PR DESCRIPTION
Two different classes called `TaskType` were imported, shadowing each other.