### PR TITLE
Add benchmarking suite for encoders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
+- Added benchmarking suite for encoders ([#360](https://github.com/pyg-team/pytorch-frame/pull/360))
 - Added dataframe text benchmark script ([#354](https://github.com/pyg-team/pytorch-frame/pull/354))
 - Added `DataFrameTextBenchmark` dataset ([#349](https://github.com/pyg-team/pytorch-frame/pull/349))
 - Added support for empty `TensorFrame` ([#339](https://github.com/pyg-team/pytorch-frame/pull/339))

--- a/benchmark/encoder/README.md
+++ b/benchmark/encoder/README.md
@@ -1,0 +1,71 @@
+# Encoder Benchmark
+
+## Usage
+
+Exemplary command:
+```
+python encoder_benchmark.py --stype-kv categorical embedding --stype-kv numerical linear
+```
+It will create a dataset that will contain categorical and numerical columns and will use for them
+embedding and linear encoders, respectively.
+
+Arguments:
+**--stype-kv**: Specify the stype(s) and corresponding encoder(s) to run.
+**--num-rows**: The number of rows in the dataset (default is *8192*).
+**--out-channels**: The number of output channels (default is *128*).
+**--with-nan**: If specified, the dataset will include NaN values.
+**--runs**: The number of runs for the benchmark (default is *1000*).
+**--warmup-size**: The size of the warmup stage (default is *200()).
+**--torch-profile**: If specified, torch profiling will be enabled.
+**--line-profile**: If specified, line profiling will be enabled.
+**--line-profile-level**: The level of line profiling (default is *'encode_forward'*).
+**--device**: The device to run the benchmark on (default is *'cpu'*).
+
+No matter if any profiler is used, benchmark always outputs a latency (single run execution time), e.g.:
+```
+Latency: 0.034277s
+```
+
+Torch profiler produces a table of operations sorted by execution time, e.g.:
+```
+-----------------------------  ------------  ------------  ------------  ------------  ------------  ------------
+                         Name    Self CPU %      Self CPU   CPU total %     CPU total  CPU time avg    # of Calls
+-----------------------------  ------------  ------------  ------------  ------------  ------------  ------------
+                    aten::cat        47.49%        2.027s        48.05%        2.051s       1.025ms          2000
+             aten::nan_to_num        19.74%     842.584ms        39.35%        1.680s     419.945us          4000
+                    aten::add        10.04%     428.549ms        10.04%     428.549ms     214.274us          2000
+           aten::index_select         6.28%     268.051ms         7.78%     331.959ms     165.980us          2000
+                    aten::mul         4.96%     211.853ms         4.96%     211.853ms     211.853us          1000
+                    aten::sub         1.36%      58.064ms         1.36%      58.064ms      58.064us          1000
+                    aten::any         1.30%      55.612ms         1.41%      60.278ms      30.139us          2000
+                    aten::div         1.22%      52.159ms         1.22%      52.159ms      52.159us          1000
+                    ...
+-----------------------------  ------------  ------------  ------------  ------------  ------------  ------------
+Self CPU time total: 4.268s
+```
+
+Line profiler shows how many percent was spent on each of method lines, e.g.:
+```
+Total time: 1.03661 s
+File: {PF_BASE_PATH}/pytorch-frame/torch_frame/nn/encoder/stype_encoder.py
+Function: encode_forward at line 295
+
+Line #      Hits         Time  Per Hit   % Time  Line Contents
+==============================================================
+   295                                               def encode_forward(
+   296                                                   self,
+   297                                                   feat: Tensor,
+   298                                                   col_names: list[str] | None = None,
+   299                                               ) -> Tensor:
+   300                                                   # TODO: Make this more efficient.
+   301                                                   # Increment the index by one so that NaN index (-1) becomes 0
+   302                                                   # (padding_idx)
+   303                                                   # feat: [batch_size, num_cols]
+   304      1200      29867.4     24.9      2.9          feat = feat + 1
+   305      1200        944.3      0.8      0.1          xs = []
+   306      3600      19345.7      5.4      1.9          for i, emb in enumerate(self.embs):
+   307      2400     466967.7    194.6     45.0              xs.append(emb(feat[:, i]))
+   308                                                   # [batch_size, num_cols, hidden_channels]
+   309      1200     519044.9    432.5     50.1          x = torch.stack(xs, dim=1)
+   310      1200        440.8      0.4      0.0          return x
+```

--- a/benchmark/encoder/encoder_benchmark.py
+++ b/benchmark/encoder/encoder_benchmark.py
@@ -1,0 +1,214 @@
+import time
+from argparse import ArgumentParser
+from contextlib import nullcontext
+from typing import Dict
+
+import torch
+from line_profiler import profile
+
+from torch_frame import NAStrategy, stype
+from torch_frame.config import ModelConfig
+from torch_frame.config.text_embedder import TextEmbedderConfig
+from torch_frame.config.text_tokenizer import TextTokenizerConfig
+from torch_frame.datasets import FakeDataset
+from torch_frame.nn import (
+    EmbeddingEncoder,
+    ExcelFormerEncoder,
+    LinearBucketEncoder,
+    LinearEmbeddingEncoder,
+    LinearEncoder,
+    LinearModelEncoder,
+    LinearPeriodicEncoder,
+    MultiCategoricalEmbeddingEncoder,
+    StackEncoder,
+    StypeEncoder,
+    StypeWiseFeatureEncoder,
+    TimestampEncoder,
+)
+from torch_frame.testing.text_embedder import HashTextEmbedder
+from torch_frame.testing.text_tokenizer import (
+    RandomTextModel,
+    WhiteSpaceHashTokenizer,
+)
+
+parser = ArgumentParser(description='Benchmark for encoder')
+parser.add_argument(
+    '--stype-kv', nargs=2, action='append', required=True,
+    help='Specify the stype(s) and corresponding encoder(s) to run. '
+    'Possible stypes are: categorical, embedding, multicategorical, '
+    'numerical, sequence_numerical, text_embedded, text_tokenized, '
+    'timestamp. Possible encoders are: embedding, excel_former, linear, '
+    'linear_bucket, linear_embedding, linear_model, linear_periodic, '
+    'multicategorical_embedding, stack, timestamp. '
+    'Example: --stype-kv categorical embedding --stype-kv numerical linear')
+parser.add_argument('--num-rows', type=int, default=8192)
+parser.add_argument('--out-channels', type=int, default=128)
+parser.add_argument('--with-nan', action='store_true')
+parser.add_argument('--runs', type=int, default=1000)
+parser.add_argument('--warmup-size', type=int, default=200)
+parser.add_argument('--torch-profile', action='store_true')
+parser.add_argument('--line-profile', action='store_true')
+parser.add_argument(
+    '--line-profile-level', type=str,
+    choices=['stypewise_forward', 'stype_forward',
+             'encode_forward'], default='encode_forward')
+parser.add_argument('--device', type=str, choices=['cpu'], default='cpu')
+
+args = parser.parse_args()
+
+stype_str2stype = {
+    'categorical': stype.categorical,
+    'embedding': stype.embedding,
+    'multicategorical': stype.multicategorical,
+    'numerical': stype.numerical,
+    'sequence_numerical': stype.sequence_numerical,
+    'text_embedded': stype.text_embedded,
+    'text_tokenized': stype.text_tokenized,
+    'timestamp': stype.timestamp,
+}
+
+encoder_str2encoder = {
+    'embedding': EmbeddingEncoder,
+    'excel_former': ExcelFormerEncoder,
+    'linear': LinearEncoder,
+    'linear_bucket': LinearBucketEncoder,
+    'linear_embedding': LinearEmbeddingEncoder,
+    'linear_model': LinearModelEncoder,
+    'linear_periodic': LinearPeriodicEncoder,
+    'multicategorical_embedding': MultiCategoricalEmbeddingEncoder,
+    'stack': StackEncoder,
+    'timestamp': TimestampEncoder,
+}
+
+encoder_str2encoder_cls_kwargs = {
+    'embedding': {
+        "na_strategy": NAStrategy.MOST_FREQUENT,
+    },
+    'excel_former': {},
+    'linear': {
+        "na_strategy": NAStrategy.MEAN,
+    },
+    'linear_bucket': {
+        "na_strategy": NAStrategy.MEAN,
+    },
+    'linear_embedding': {},
+    'linear_model': {
+        "col_to_model_cfg": {
+            "text_tokenized_1":
+            ModelConfig(model=RandomTextModel(args.out_channels * 4),
+                        out_channels=args.out_channels * 4),
+            "text_tokenized_2":
+            ModelConfig(model=RandomTextModel(args.out_channels * 2),
+                        out_channels=args.out_channels * 2)
+        },
+    },
+    'linear_periodic': {
+        "na_strategy": NAStrategy.MEAN,
+    },
+    'multicategorical_embedding': {
+        "na_strategy": NAStrategy.ZEROS
+    },
+    'stack': {},
+    'timestamp': {
+        "na_strategy": NAStrategy.MEDIAN_TIMESTAMP
+    },
+}
+
+
+def make_stype_encoder_dict() -> Dict[stype, StypeEncoder]:
+    stype_encoder_dict = {}
+    for stype_str, encoder_str in args.stype_kv:
+        encoder_kwargs = encoder_str2encoder_cls_kwargs[encoder_str]
+        stype_encoder_dict[
+            stype_str2stype[stype_str]] = encoder_str2encoder[encoder_str](
+                **encoder_kwargs)
+
+    return stype_encoder_dict
+
+
+def make_fake_dataset() -> FakeDataset:
+    stypes = [stype_str2stype[stype_str] for stype_str, _ in args.stype_kv]
+    dataset = FakeDataset(
+        num_rows=args.num_rows, with_nan=args.with_nan, stypes=stypes,
+        col_to_text_embedder_cfg=TextEmbedderConfig(
+            text_embedder=HashTextEmbedder(out_channels=args.out_channels *
+                                           2, ),
+            batch_size=None,
+        ), col_to_text_tokenizer_cfg=TextTokenizerConfig(
+            text_tokenizer=WhiteSpaceHashTokenizer(),
+            batch_size=None,
+        ))
+    dataset.materialize(torch.device(args.device))
+
+    return dataset
+
+
+def run_profiling():
+    if args.line_profile and args.torch_profile:
+        raise ValueError(
+            'You cannot enable both line profiling and torch profiling '
+            'at the same time.')
+    if not all(stype_str in stype_str2stype for stype_str, _ in args.stype_kv):
+        raise ValueError('Invalid stype string.')
+    if not all(encoder_str in encoder_str2encoder
+               for _, encoder_str in args.stype_kv):
+        raise ValueError('Invalid encoder string.')
+    if 'linear_model' in [encoder_str for _, encoder_str in args.stype_kv]:
+        if 'text_tokenized' not in [
+                stype_str for stype_str, _ in args.stype_kv
+        ]:
+            raise ValueError(
+                'If you want to use linear_model encoder, you must specify '
+                'text_tokenized stype.')
+
+    if args.warmup_size == 0:
+        args.warmup_size = args.runs // 5
+        print('Warm-up size is not specified. Using 1/5 of the runs as the '
+              'warm-up size.')
+
+    print('BENCHMARK STARTS')
+    print('Preparing the data...')
+
+    dataset = make_fake_dataset()
+    stype_encoder_dict = make_stype_encoder_dict()
+
+    if args.line_profile:
+        if args.line_profile_level == 'encode_forward':
+            for encoder in stype_encoder_dict.values():
+                encoder.encode_forward = profile(encoder.encode_forward)
+        elif args.line_profile_level == 'stype_forward':
+            for encoder in stype_encoder_dict.values():
+                encoder.forward = profile(encoder.forward)
+
+    tensor_frame = dataset.tensor_frame
+    encoder = StypeWiseFeatureEncoder(
+        out_channels=args.out_channels, col_stats=dataset.col_stats,
+        col_names_dict=tensor_frame.col_names_dict,
+        stype_encoder_dict=stype_encoder_dict)
+
+    if args.line_profile and args.line_profile_level == 'stypewise_forward':
+        encoder.forward = profile(encoder.forward)
+
+    profiler_context = torch.autograd.profiler.profile(
+    ) if args.torch_profile else nullcontext()
+
+    print('Performing warm-up stage...')
+    for _ in range(args.warmup_size):
+        encoder(tensor_frame)
+
+    print('Running benchmark...')
+    with profiler_context as prof:
+        start = time.perf_counter()
+        for _ in range(args.runs):
+            encoder(tensor_frame)
+        elapsed = time.perf_counter() - start
+        latency = elapsed / args.runs
+        print(f'Latency: {latency:.6f}s')
+
+    if args.torch_profile:
+        sort_by = f'self_{args.device}_time_total'
+        print(prof.key_averages().table(sort_by=sort_by, row_limit=20))
+
+
+if __name__ == '__main__':
+    run_profiling()


### PR DESCRIPTION
Preliminary benchmarks of [RelBench](https://github.com/snap-stanford/relbench/blob/main/examples/gnn.py) showed that a lot of execution time is spent on encoders. This PR introduces encoders benchmarking suite that can server as a tool for performance inspection.