### PR TITLE
Improve performance of Encoder's `na_forward` method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 
+- Changed a workflow of Encoder's `na_forward` method resulting in performance boost ([#364](https://github.com/pyg-team/pytorch-frame/pull/364))
+
 ### Deprecated
 
 ### Removed


### PR DESCRIPTION
This PR introduces small improvements that resulted in an average 1.5x speedup in `na_forward` execution time.
`get_na_mask` is a heavy operation, whose result may be cached at the pre-condition checking step.
Additionally, when we deal with 2D `feat`, we can use `torch.where` to efficiently fill `NaN`s across all columns.