### PR TITLE
Fix `mpmath` version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,7 @@ full=[
     "scikit-learn",
     "xgboost>=1.7.0, <2.0.0",
     "optuna>=3.0.0",
+    "mpmath==1.3.0",
     "catboost",
     "lightgbm",
     "datasets",


### PR DESCRIPTION
To avoid bug related to the recent `mpmath` version upgrade.
```
FAILED test/nn/models/test_compile.py::test_compile_graph_break[FTTransformer] - AttributeError: module 'mpmath' has no attribute 'rational'
FAILED test/nn/models/test_compile.py::test_compile_graph_break[ResNet] - AttributeError: module 'mpmath' has no attribute 'rational'
FAILED test/nn/models/test_compile.py::test_compile_graph_break[TabNet] - AttributeError: module 'mpmath' has no attribute 'rational'
FAILED test/nn/models/test_compile.py::test_compile_graph_break[TabTransformer] - AttributeError: module 'mpmath' has no attribute 'rational'
FAILED test/nn/models/test_compile.py::test_compile_graph_break[Trompt] - AttributeError: module 'mpmath' has no attribute 'rational'
FAILED test/nn/models/test_compile.py::test_compile_graph_break[ExcelFormer] - AttributeError: module 'mpmath' has no attribute 'rational'
```