### PR TITLE
Add `torchmetrics` to `pyproject.py` full dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,6 +54,7 @@ full=[
     "catboost",
     "lightgbm",
     "datasets",
+    "torchmetrics",
 ]
 
 [project.urls]


### PR DESCRIPTION
Add `torchmetrics` to `pyproject.py` full dependencies
As we need to use it in the benchmark