### PR TITLE
[FutureWarn] Fix FutureWarning in `CategoricalTensorMapper`.

### DIFF
--- a/torch_frame/data/mapper.py
+++ b/torch_frame/data/mapper.py
@@ -110,7 +110,7 @@ class CategoricalTensorMapper(TensorMapper):
 
     def backward(self, tensor: Tensor) -> pd.Series:
         index = tensor.cpu().numpy()
-        ser = pd.Series(self.categories[index].index)
+        ser = pd.Series(self.categories.iloc[index].index)
         ser[index < 0] = None
         return ser
 


### PR DESCRIPTION
The following FutureWarning is fixed:
```
test/data/test_mapper.py::test_categorical_tensor_mapper
  /usr/local/lib/python3.10/dist-packages/torch_frame/data/mapper.py:113: FutureWarning: Series.__getitem__ 
treating keys as positions is deprecated. In a future version, integer keys will always be treated as labels 
(consistent with DataFrame behavior). To access a value by position, use `ser.iloc[pos]`
    ser = pd.Series(self.categories[index].index)
```