### PR TITLE
[UserWarning] Fixing UserWarnings in two tests.

### DIFF
--- a/test/transforms/test_cat_to_num_transform.py
+++ b/test/transforms/test_cat_to_num_transform.py
@@ -135,7 +135,8 @@ def test_cat_to_num_transform_with_loading(task_type):
         # (num_count + target_mean)/(num_rows + 1).
         # This test tests the correctness in multiclass classification
         # task.
-        src = (num_rows + dataset.tensor_frame.y.float().mean())/(num_rows + 1)
+        src = (num_rows + dataset.tensor_frame.y.float().mean()) / (num_rows +
+                                                                    1)
         assert torch.allclose(
             out.feat_dict[stype.numerical][:, total_numerical_cols].float(),
             src.clone().detach().to(out.device).repeat(num_rows))

--- a/test/transforms/test_cat_to_num_transform.py
+++ b/test/transforms/test_cat_to_num_transform.py
@@ -52,10 +52,10 @@ def test_cat_to_num_transform_on_categorical_only_dataset(with_nan):
     # The transform uses m-target estimation, where each categorical
     # feature is transformed to (num_count + target_mean)/(num_rows + 1).
     # This test tests the correctness in multiclass classification task.
-    source_tensor = (num_rows + target_mean[0]) / (num_rows + 1)
+    src_tensor = (num_rows + target_mean[0]) / (num_rows + 1)
     assert torch.allclose(
         out.feat_dict[stype.numerical][:, 0].float(),
-        source_tensor.clone().detach().to(out.device).repeat(num_rows))
+        src_tensor.clone().detach().to(out.device).repeat(num_rows))
 
     # assert that there are no categorical features
     assert (stype.categorical not in out.col_names_dict)

--- a/test/transforms/test_cat_to_num_transform.py
+++ b/test/transforms/test_cat_to_num_transform.py
@@ -52,10 +52,10 @@ def test_cat_to_num_transform_on_categorical_only_dataset(with_nan):
     # The transform uses m-target estimation, where each categorical
     # feature is transformed to (num_count + target_mean)/(num_rows + 1).
     # This test tests the correctness in multiclass classification task.
+    source_tensor = (num_rows + target_mean[0]) / (num_rows + 1)
     assert torch.allclose(
         out.feat_dict[stype.numerical][:, 0].float(),
-        torch.tensor((num_rows + target_mean[0]) / (num_rows + 1),
-                     device=out.device).repeat(num_rows))
+        source_tensor.clone().detach().to(out.device).repeat(num_rows))
 
     # assert that there are no categorical features
     assert (stype.categorical not in out.col_names_dict)
@@ -135,10 +135,10 @@ def test_cat_to_num_transform_with_loading(task_type):
         # (num_count + target_mean)/(num_rows + 1).
         # This test tests the correctness in multiclass classification
         # task.
+        src = (num_rows + dataset.tensor_frame.y.float().mean())/(num_rows + 1)
         assert torch.allclose(
             out.feat_dict[stype.numerical][:, total_numerical_cols].float(),
-            torch.tensor((num_rows + dataset.tensor_frame.y.float().mean()) /
-                         (num_rows + 1), device=out.device).repeat(num_rows))
+            src.clone().detach().to(out.device).repeat(num_rows))
     else:
         # when the task is multiclass classification, the number of
         # columns changes.


### PR DESCRIPTION
The following UserWarnings are fixed:
```
test/transforms/test_cat_to_num_transform.py::test_cat_to_num_transform_on_categorical_only_dataset[True]
test/transforms/test_cat_to_num_transform.py::test_cat_to_num_transform_on_categorical_only_dataset[False]
  /opt/pyg/pytorch-frame/test/transforms/test_cat_to_num_transform.py:55: UserWarning: To copy construct from a tensor, 
it is recommended to use sourceTensor.clone().detach() or sourceTensor.clone().detach().requires_grad_(True), rather 
than torch.tensor(sourceTensor).
    assert torch.allclose(

test/transforms/test_cat_to_num_transform.py::test_cat_to_num_transform_with_loading[TaskType.REGRESSION]
test/transforms/test_cat_to_num_transform.py::test_cat_to_num_transform_with_loading[TaskType.BINARY_CLASSIFICATION]
  /opt/pyg/pytorch-frame/test/transforms/test_cat_to_num_transform.py:138: UserWarning: To copy construct from a tensor, 
it is recommended to use sourceTensor.clone().detach() or sourceTensor.clone().detach().requires_grad_(True), rather 
than torch.tensor(sourceTensor).
    assert torch.allclose(
```