### PR TITLE
Fixing Bug in Version Handling.

### DIFF
--- a/torch_frame/testing/decorators.py
+++ b/torch_frame/testing/decorators.py
@@ -4,7 +4,7 @@ from typing import Callable
 
 import torch
 from packaging.requirements import Requirement
-
+from packaging.version import Version
 
 def has_package(package: str) -> bool:
     r"""Returns :obj:`True` in case :obj:`package` is installed."""
@@ -18,12 +18,7 @@ def has_package(package: str) -> bool:
     if not hasattr(module, '__version__'):
         return True
 
-    version = module.__version__
-    # `req.specifier` does not support `.dev` suffixes, e.g., for
-    # `pyg_lib==0.1.0.dev*`, so we manually drop them:
-    if '.dev' in version:
-        version = '.'.join(version.split('.dev')[:-1])
-
+    version = Version(module.__version__).base_version
     return version in req.specifier
 
 

--- a/torch_frame/testing/decorators.py
+++ b/torch_frame/testing/decorators.py
@@ -6,6 +6,7 @@ import torch
 from packaging.requirements import Requirement
 from packaging.version import Version
 
+
 def has_package(package: str) -> bool:
     r"""Returns :obj:`True` in case :obj:`package` is installed."""
     if '|' in package:


### PR DESCRIPTION
I've noticed that the tests with the `withPackage` test decorators
```
@withPackage("torch>=2.1.0")
def test_some_test(...):
    . . .
```
are not being executed, even though I have `torch=2.4.0` installed on my machine.
```
nn/models/test_compile.py::test_compile_graph_break[FTTransformer] SKIPPED (Package(s) {'torch>=2.1.0'} are not installed)
```
To be precise, I am using Torch version `2.4.0a0+f70bd71a48.nv24.06` which has an unexpected version ID format for the  for `pytorch-frame` .

The proposed PR uses standard [Python version handling](https://packaging.python.org/en/latest/specifications/version-specifiers/), which covers the `dev` case previously treated separately.
