### PR TITLE
Remove CUDA synchronizations by slicing input tensor with `int` instead of CUDA tensors in `nn.LinearEmbeddingEncoder`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
+- Removed CUDA synchronizations in `nn.LinearEmbeddingEncoder` ([#432](https://github.com/pyg-team/pytorch-frame/pull/432))
+
 ## [0.2.3] - 2024-07-08
 
 ### Added


### PR DESCRIPTION
`start_idx` and `end_idx` used at `feat.values[:, start_idx:end_idx]` are on device, which leads to cuda synchronizations.