### PR TITLE
Improve Stats compute perf

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -5,6 +5,7 @@ on:  # yamllint disable-line rule:truthy
     branches:
       - master
   pull_request:
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}-${{ github.head_ref }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Changed
 
+- Improved performance of `StatType.compute` for numerical columns ([#449](https://github.com/pyg-team/pytorch-frame/pull/449))
+
 ### Deprecated
 
 ### Removed

--- a/torch_frame/data/stats.py
+++ b/torch_frame/data/stats.py
@@ -85,7 +85,8 @@ class StatType(Enum):
         sep: str | None = None,
     ) -> Any:
         if self == StatType.MEAN:
-            flattened = np.hstack(np.hstack(ser.values))
+            val = np.hstack(ser.values) if ser.values.ndim > 1 else ser.values
+            flattened = np.hstack(val) if val.ndim > 1 else val
             finite_mask = np.isfinite(flattened)
             if not finite_mask.any():
                 # NOTE: We may just error out here if eveything is NaN
@@ -93,14 +94,16 @@ class StatType(Enum):
             return np.mean(flattened[finite_mask]).item()
 
         elif self == StatType.STD:
-            flattened = np.hstack(np.hstack(ser.values))
+            val = np.hstack(ser.values) if ser.values.ndim > 1 else ser.values
+            flattened = np.hstack(val) if val.ndim > 1 else val
             finite_mask = np.isfinite(flattened)
             if not finite_mask.any():
                 return np.nan
             return np.std(flattened[finite_mask]).item()
 
         elif self == StatType.QUANTILES:
-            flattened = np.hstack(np.hstack(ser.values))
+            val = np.hstack(ser.values) if ser.values.ndim > 1 else ser.values
+            flattened = np.hstack(val) if val.ndim > 1 else val
             finite_mask = np.isfinite(flattened)
             if not finite_mask.any():
                 return [np.nan, np.nan, np.nan, np.nan, np.nan]

--- a/torch_frame/data/stats.py
+++ b/torch_frame/data/stats.py
@@ -16,6 +16,14 @@ from torch_frame.data.mapper import (
 from torch_frame.typing import Series
 
 
+def _flatten_numeric(values: np.ndarray) -> np.ndarray:
+    # Fast path: already a 1D numeric array (e.g., the `numerical` stype).
+    # Avoids the expensive `np.hstack` call used for nested sequences.
+    if values.dtype != object and values.ndim == 1:
+        return values
+    return np.hstack(values)
+
+
 class StatType(Enum):
     r"""The different types for column statistics.
 
@@ -85,8 +93,7 @@ class StatType(Enum):
         sep: str | None = None,
     ) -> Any:
         if self == StatType.MEAN:
-            val = np.hstack(ser.values) if ser.values.ndim > 1 else ser.values
-            flattened = np.hstack(val) if val.ndim > 1 else val
+            flattened = _flatten_numeric(ser.values)
             finite_mask = np.isfinite(flattened)
             if not finite_mask.any():
                 # NOTE: We may just error out here if eveything is NaN
@@ -94,16 +101,14 @@ class StatType(Enum):
             return np.mean(flattened[finite_mask]).item()
 
         elif self == StatType.STD:
-            val = np.hstack(ser.values) if ser.values.ndim > 1 else ser.values
-            flattened = np.hstack(val) if val.ndim > 1 else val
+            flattened = _flatten_numeric(ser.values)
             finite_mask = np.isfinite(flattened)
             if not finite_mask.any():
                 return np.nan
             return np.std(flattened[finite_mask]).item()
 
         elif self == StatType.QUANTILES:
-            val = np.hstack(ser.values) if ser.values.ndim > 1 else ser.values
-            flattened = np.hstack(val) if val.ndim > 1 else val
+            flattened = _flatten_numeric(ser.values)
             finite_mask = np.isfinite(flattened)
             if not finite_mask.any():
                 return [np.nan, np.nan, np.nan, np.nan, np.nan]


### PR DESCRIPTION
This PR improves performance of `StatType.compute` by calling `np.hstack` only when needed. 

Before change:
```
$ time python  gnn_node.py --dataset=rel-hm --task=user-churn --epochs 1 --max_steps_per_epoch 250
[...]
real    3m17.517s
user    3m19.252s
sys     0m6.757s
```

After change:

```
$ time python  gnn_node.py --dataset=rel-hm --task=user-churn --epochs 1 --max_steps_per_epoch 250
[...]
real    1m43.020s
user    1m45.716s
sys     0m6.022s
```