### PR TITLE
Fix offset in LinearEmbeddingEncoder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
+- Fixed offset in `LinearEmbeddingEncoder` [#455](https://github.com/pyg-team/pytorch-frame/pull/455)
 - Added a benchmark script to compare PyTorch Frame with PyTorch Tabular ([#398](https://github.com/pyg-team/pytorch-frame/pull/398), [#444](https://github.com/pyg-team/pytorch-frame/pull/444))
 - Added `is_floating_point` method to `MultiNestedTensor` and `MultiEmbeddingTensor` ([#445](https://github.com/pyg-team/pytorch-frame/pull/445))
 - Added support for inferring `stype.categorical` from boolean columns in `utils.infer_series_stype` ([#421](https://github.com/pyg-team/pytorch-frame/pull/421))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,6 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
-- Fixed offset in `LinearEmbeddingEncoder` [#455](https://github.com/pyg-team/pytorch-frame/pull/455)
 - Added a benchmark script to compare PyTorch Frame with PyTorch Tabular ([#398](https://github.com/pyg-team/pytorch-frame/pull/398), [#444](https://github.com/pyg-team/pytorch-frame/pull/444))
 - Added `is_floating_point` method to `MultiNestedTensor` and `MultiEmbeddingTensor` ([#445](https://github.com/pyg-team/pytorch-frame/pull/445))
 - Added support for inferring `stype.categorical` from boolean columns in `utils.infer_series_stype` ([#421](https://github.com/pyg-team/pytorch-frame/pull/421))

--- a/torch_frame/nn/encoder/stype_encoder.py
+++ b/torch_frame/nn/encoder/stype_encoder.py
@@ -732,6 +732,7 @@ class LinearEmbeddingEncoder(StypeEncoder):
             # -> [batch_size, out_channels]
             x_lin = feat.values[:, start_idx:end_idx] @ self.weight_list[idx]
             x_lins.append(x_lin)
+            start_idx = end_idx
         # [batch_size, num_cols, out_channels]
         x = torch.stack(x_lins, dim=1)
         # [batch_size, num_cols, out_channels] + [num_cols, out_channels]


### PR DESCRIPTION
This PR fixes an issue in the `LinearEmbeddingEncoder` class. The forward function does not increment the `start_idx` variable, so only the first one is used correctly if multiple embedding columns are present.

This probably affects the results in the [RelBench](https://arxiv.org/pdf/2407.20060) paper, so I suggest double-checking those.

