### PR TITLE
Consistent PyPI name `pytorch-frame`

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -26,7 +26,7 @@ To develop PyTorch Frame on your machine, here are some tips:
    It is advised to run this command repeatedly to confirm that installations across all locations are properly removed.
 
    ```bash
-   pip uninstall pytorch_frame
+   pip uninstall pytorch-frame
    ```
 
 1. Fork and clone the PyTorch Frame repository:

--- a/README.md
+++ b/README.md
@@ -248,7 +248,7 @@ The benchmark script for Hugging Face text encoders is in this [file](https://gi
 PyTorch Frame is available for Python 3.9 to Python 3.11.
 
 ```
-pip install pytorch_frame
+pip install pytorch-frame
 ```
 
 See [the installation guide](https://pytorch-frame.readthedocs.io/en/latest/get_started/installation.html) for other options.

--- a/docs/source/get_started/installation.rst
+++ b/docs/source/get_started/installation.rst
@@ -8,10 +8,10 @@ Installation via PyPI
 
 .. code-block:: none
 
-   pip install pytorch_frame
+   pip install pytorch-frame
 
    # Install with optional dependencies
-   pip install pytorch_frame[full]
+   pip install pytorch-frame[full]
 
 
 Installation from master

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires=["flit_core >=3.2,<4"]
 build-backend="flit_core.buildapi"
 
 [project]
-name="pytorch_frame"
+name="pytorch-frame"
 version="0.2.3"
 authors=[
     {name="PyG Team", email="team@pyg.org"},
@@ -42,7 +42,7 @@ test=[
     "mypy",
 ]
 dev=[
-    "pytorch_frame[test]",
+    "pytorch-frame[test]",
     "pre-commit",
 ]
 full=[


### PR DESCRIPTION
This PR makes a cosmetic change and makes no change that affects users.

`-` and `_` mean the same thing at pypi.org/project/pytorch-frame as per https://packaging.python.org/en/latest/specifications/name-normalization/#name-normalization.