### PR TITLE
Add an example of training a tabular model on multiple GPUs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
-- Added an example for multi-GPU training of `Trompt` ([#474](https://github.com/pyg-team/pytorch-frame/pull/474))
+- Added an example for training `Trompt` on multiple GPUs ([#474](https://github.com/pyg-team/pytorch-frame/pull/474))
 - Added support for PyTorch 2.5 ([#464](https://github.com/pyg-team/pytorch-frame/pull/464))
 - Added a benchmark script to compare PyTorch Frame with PyTorch Tabular ([#398](https://github.com/pyg-team/pytorch-frame/pull/398), [#444](https://github.com/pyg-team/pytorch-frame/pull/444))
 - Added `is_floating_point` method to `MultiNestedTensor` and `MultiEmbeddingTensor` ([#445](https://github.com/pyg-team/pytorch-frame/pull/445))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
+- Added an example for multi-GPU training of `Trompt` ([#474](https://github.com/pyg-team/pytorch-frame/pull/474))
 - Added support for PyTorch 2.5 ([#464](https://github.com/pyg-team/pytorch-frame/pull/464))
 - Added a benchmark script to compare PyTorch Frame with PyTorch Tabular ([#398](https://github.com/pyg-team/pytorch-frame/pull/398), [#444](https://github.com/pyg-team/pytorch-frame/pull/444))
 - Added `is_floating_point` method to `MultiNestedTensor` and `MultiEmbeddingTensor` ([#445](https://github.com/pyg-team/pytorch-frame/pull/445))

--- a/benchmark/data_frame_benchmark.py
+++ b/benchmark/data_frame_benchmark.py
@@ -263,7 +263,7 @@ def train(
             pred, y = model(tf, mixup_encoded=True)
         elif isinstance(model, Trompt):
             # Trompt uses the layer-wise loss
-            pred = model.forward_stacked(tf)
+            pred = model(tf)
             num_layers = pred.size(1)
             # [batch_size * num_layers, num_classes]
             pred = pred.view(-1, out_channels)
@@ -294,6 +294,8 @@ def test(
     for tf in loader:
         tf = tf.to(device)
         pred = model(tf)
+        if isinstance(model, Trompt):
+            pred = pred.mean(dim=1)
         if dataset.task_type == TaskType.MULTICLASS_CLASSIFICATION:
             pred = pred.argmax(dim=-1)
         elif dataset.task_type == TaskType.REGRESSION:

--- a/benchmark/data_frame_text_benchmark.py
+++ b/benchmark/data_frame_text_benchmark.py
@@ -307,7 +307,7 @@ def train(
         y = tf.y
         if isinstance(model, Trompt):
             # Trompt uses the layer-wise loss
-            pred = model.forward_stacked(tf)
+            pred = model(tf)
             num_layers = pred.size(1)
             # [batch_size * num_layers, num_classes]
             pred = pred.view(-1, out_channels)
@@ -337,6 +337,10 @@ def test(
     for tf in loader:
         tf = tf.to(device)
         pred = model(tf)
+        if isinstance(model, Trompt):
+            # [batch_size, num_layers, out_channels]
+            # -> [batch_size, out_channels]
+            pred = pred.mean(dim=1)
         if dataset.task_type == TaskType.MULTICLASS_CLASSIFICATION:
             pred = pred.argmax(dim=-1)
         elif dataset.task_type == TaskType.REGRESSION:

--- a/examples/trompt.py
+++ b/examples/trompt.py
@@ -90,7 +90,7 @@ def train(epoch: int) -> float:
     for tf in tqdm(train_loader, desc=f"Epoch: {epoch}"):
         tf = tf.to(device)
         # [batch_size, num_layers, num_classes]
-        out = model.forward_stacked(tf)
+        out = model(tf)
         num_layers = out.size(1)
         # [batch_size * num_layers, num_classes]
         pred = out.view(-1, dataset.num_classes)
@@ -112,7 +112,7 @@ def test(loader: DataLoader) -> float:
 
     for tf in loader:
         tf = tf.to(device)
-        pred = model(tf)
+        pred = model(tf).mean(dim=1)
         pred_class = pred.argmax(dim=-1)
         accum += float((tf.y == pred_class).sum())
         total_count += len(tf.y)

--- a/examples/trompt_multi_gpu.py
+++ b/examples/trompt_multi_gpu.py
@@ -179,7 +179,6 @@ def run(rank: int, world_size: int, args: argparse.Namespace) -> None:
     model = torch.compile(model) if args.compile else model
     optimizer = torch.optim.Adam(model.parameters(), lr=args.lr)
     lr_scheduler = ExponentialLR(optimizer, gamma=0.95)
-
     metrics_kwargs = {
         "task": "multiclass",
         "num_classes": dataset.num_classes,
@@ -187,7 +186,6 @@ def run(rank: int, world_size: int, args: argparse.Namespace) -> None:
     train_metric = torchmetrics.Accuracy(**metrics_kwargs).to(rank)
     val_metric = torchmetrics.Accuracy(**metrics_kwargs).to(rank)
     test_metric = torchmetrics.Accuracy(**metrics_kwargs).to(rank)
-
     best_val_acc = 0.0
     test_acc = 0.0
     for epoch in range(1, args.epochs + 1):

--- a/examples/trompt_multi_gpu.py
+++ b/examples/trompt_multi_gpu.py
@@ -240,7 +240,6 @@ if __name__ == "__main__":
     parser.add_argument("--lr", type=float, default=0.001)
     parser.add_argument("--epochs", type=int, default=200)
     parser.add_argument("--seed", type=int, default=0)
-    parser.add_argument("--compile", action="store_true")
     args = parser.parse_args()
 
     os.environ['MASTER_ADDR'] = 'localhost'

--- a/examples/trompt_multi_gpu.py
+++ b/examples/trompt_multi_gpu.py
@@ -65,10 +65,13 @@ def train(
         with torch.no_grad():
             metric.update(out.mean(dim=1).argmax(dim=-1), tf.y)
 
-        _, num_layers, num_classes = out.size()
+        batch_size, num_layers, num_classes = out.size()
         # [batch_size * num_layers, num_classes]
         pred = out.view(-1, num_classes)
-        y = tf.y.repeat_interleave(num_layers)
+        y = tf.y.repeat_interleave(
+            num_layers,
+            output_size=num_layers * batch_size,
+        )
         # Layer-wise logit loss
         loss = F.cross_entropy(pred, y)
         loss.backward()

--- a/examples/trompt_multi_gpu.py
+++ b/examples/trompt_multi_gpu.py
@@ -55,7 +55,7 @@ def train(
     loss_accum = torch.tensor(0.0, device=rank, dtype=torch.float32)
     for tf in tqdm(
             loader,
-            desc=f"Epoch {epoch:02d} (train)",
+            desc=f"Epoch {epoch:03d} (train)",
             disable=rank != 0,
     ):
         tf = tf.to(rank)
@@ -96,7 +96,7 @@ def test(
     model.eval()
     for tf in tqdm(
             loader,
-            desc=f"Epoch {epoch:02d} ({desc})",
+            desc=f"Epoch {epoch:03d} ({desc})",
             disable=rank != 0,
     ):
         tf = tf.to(rank)

--- a/examples/trompt_multi_gpu.py
+++ b/examples/trompt_multi_gpu.py
@@ -174,6 +174,7 @@ def run(rank: int, world_size: int, args: argparse.Namespace) -> None:
         col_names_dict=train_dataset.tensor_frame.col_names_dict,
     ).to(rank)
     model = DistributedDataParallel(model, device_ids=[rank])
+    model = torch.compile(model) if args.compile else model
     optimizer = torch.optim.Adam(model.parameters(), lr=args.lr)
     lr_scheduler = ExponentialLR(optimizer, gamma=0.95)
 
@@ -240,6 +241,7 @@ if __name__ == "__main__":
     parser.add_argument("--lr", type=float, default=0.001)
     parser.add_argument("--epochs", type=int, default=50)
     parser.add_argument("--seed", type=int, default=0)
+    parser.add_argument("--compile", action="store_true")
     args = parser.parse_args()
 
     os.environ['MASTER_ADDR'] = 'localhost'

--- a/examples/trompt_multi_gpu.py
+++ b/examples/trompt_multi_gpu.py
@@ -79,8 +79,6 @@ def train(
         optimizer.zero_grad()
         loss_accum += loss
 
-    # The number of samples is guaranteed to be the same across all ranks
-    # because of DistributedSampler(drop_last=True).
     dist.all_reduce(loss_accum, op=dist.ReduceOp.AVG)
     metric_value = metric.compute()
     metric.reset()

--- a/examples/trompt_multi_gpu.py
+++ b/examples/trompt_multi_gpu.py
@@ -125,8 +125,7 @@ def run(rank: int, world_size: int, args: argparse.Namespace) -> None:
                 f"[%(asctime)s] %(levelname)s: %(message)s"),
         level=logging.INFO,
     )
-    logger = logging.getLogger(__name__)
-    logger.info(f"Running on rank {rank} of {world_size}")
+    logging.info(f"Initialized rank {rank}/{world_size}")
     dataset = prepare_dataset(args.dataset)
     assert dataset.task_type.is_classification
 

--- a/examples/trompt_multi_gpu.py
+++ b/examples/trompt_multi_gpu.py
@@ -1,0 +1,245 @@
+import argparse
+import logging
+import os
+import os.path as osp
+
+import torch
+import torch.distributed as dist
+import torch.multiprocessing as mp
+import torch.nn.functional as F
+import torchmetrics
+from torch.nn.parallel import DistributedDataParallel
+from torch.optim.lr_scheduler import ExponentialLR
+from torch.utils.data.distributed import DistributedSampler
+from tqdm import tqdm
+
+from torch_frame.data import DataLoader
+from torch_frame.datasets import TabularBenchmark
+from torch_frame.nn import Trompt
+
+
+def prepare_dataset(dataset_str: str) -> TabularBenchmark:
+    path = osp.join(
+        osp.dirname(osp.realpath(__file__)),
+        "..",
+        "data",
+        dataset_str,
+    )
+    materialized_path = osp.join(path, 'materialized_data.pt')
+    if dist.get_rank() == 0:
+        logging.info(f"Preparing dataset '{dataset_str}' from '{path}'")
+        dataset = TabularBenchmark(root=path, name=dataset_str)
+        logging.info("Materializing dataset")
+        dataset.materialize(path=materialized_path)
+
+    dist.barrier()
+    if dist.get_rank() != 0:
+        logging.info(f"Preparing dataset '{dataset_str}' from '{path}'")
+        dataset = TabularBenchmark(root=path, name=dataset_str)
+        logging.info("Loading materialized dataset")
+        dataset.materialize(path=materialized_path)
+
+    dist.barrier()
+    return dataset
+
+
+def train(
+    model: DistributedDataParallel,
+    epoch: int,
+    loader: DataLoader,
+    optimizer: torch.optim.Optimizer,
+    num_classes: int,
+    metric: torchmetrics.Metric,
+    rank: int,
+) -> float:
+    model.train()
+    loss_accum = torch.tensor(0.0, device=rank, dtype=torch.float32)
+    for tf in tqdm(loader, desc=f"Epoch {epoch:02d}", disable=rank != 0):
+        tf = tf.to(rank)
+        # [batch_size, num_layers, num_classes]
+        out = model(tf)
+        with torch.no_grad():
+            metric.update(out.mean(dim=1).argmax(dim=-1), tf.y)
+        num_layers = out.size(1)
+        # [batch_size * num_layers, num_classes]
+        pred = out.view(-1, num_classes)
+        y = tf.y.repeat_interleave(num_layers)
+        # Layer-wise logit loss
+        loss = F.cross_entropy(pred, y)
+        loss.backward()
+        optimizer.step()
+        optimizer.zero_grad()
+        loss_accum += loss
+
+    # The number of samples is guaranteed to be the same across all ranks
+    # because of DistributedSampler(drop_last=True).
+    dist.all_reduce(loss_accum, op=dist.ReduceOp.AVG)
+    metric_value = metric.compute()
+    metric.reset()
+    return loss_accum, metric_value
+
+
+@torch.no_grad()
+def test(
+    model: DistributedDataParallel,
+    epoch: int,
+    loader: DataLoader,
+    metric: torchmetrics.Metric,
+    rank: int,
+    desc: str,
+) -> float:
+    model.eval()
+    for tf in tqdm(
+            loader,
+            desc=f"Epoch {epoch:02d} ({desc})",
+            disable=rank != 0,
+    ):
+        tf = tf.to(rank)
+        # [batch_size, num_layers, num_classes] -> [batch_size, num_classes]
+        pred = model(tf).mean(dim=1)
+        pred_class = pred.argmax(dim=-1)
+        metric.update(pred_class, tf.y)
+
+    metric_value = metric.compute()
+    metric.reset()
+    return metric_value
+
+
+def run(rank, world_size, args) -> None:
+    dist.init_process_group(
+        backend='nccl',
+        init_method='env://',
+        world_size=world_size,
+        rank=rank,
+    )
+    logging.basicConfig(
+        format=f"[rank={rank}] [%(asctime)s] %(levelname)s: %(message)s",
+        level=logging.INFO,
+    )
+    logger = logging.getLogger(__name__)
+    logger.info(f"Running on rank {rank} of {world_size}")
+    dataset = prepare_dataset(args.dataset)
+    assert dataset.task_type.is_classification
+
+    # Ensure train, val and test splits are the same across all ranks by
+    # setting the seed before shuffling.
+    torch.manual_seed(args.seed)
+    dataset = dataset.shuffle()
+    train_dataset, val_dataset, test_dataset = (
+        dataset[:0.7],
+        dataset[0.7:0.79],
+        dataset[0.79:],
+    )
+    train_loader = DataLoader(
+        train_dataset.tensor_frame,
+        batch_size=args.batch_size,
+        sampler=DistributedSampler(
+            train_dataset,
+            shuffle=True,
+            drop_last=True,
+        ),
+    )
+    val_loader = DataLoader(
+        val_dataset.tensor_frame,
+        batch_size=args.batch_size,
+        sampler=DistributedSampler(
+            val_dataset,
+            shuffle=False,
+            drop_last=False,
+        ),
+    )
+    test_loader = DataLoader(
+        test_dataset.tensor_frame,
+        batch_size=args.batch_size,
+        sampler=DistributedSampler(
+            test_dataset,
+            shuffle=False,
+            drop_last=False,
+        ),
+    )
+    model = Trompt(
+        channels=args.channels,
+        out_channels=dataset.num_classes,
+        num_prompts=args.num_prompts,
+        num_layers=args.num_layers,
+        col_stats=dataset.col_stats,
+        col_names_dict=train_dataset.tensor_frame.col_names_dict,
+    ).to(rank)
+    model = DistributedDataParallel(model, device_ids=[rank])
+    optimizer = torch.optim.Adam(model.parameters(), lr=args.lr)
+    lr_scheduler = ExponentialLR(optimizer, gamma=0.95)
+
+    metrics_kwargs = {
+        "task": "multiclass",
+        "num_classes": dataset.num_classes,
+    }
+    train_metric = torchmetrics.Accuracy(**metrics_kwargs).to(rank)
+    val_metric = torchmetrics.Accuracy(**metrics_kwargs).to(rank)
+    test_metric = torchmetrics.Accuracy(**metrics_kwargs).to(rank)
+
+    best_val_acc = 0.0
+    best_test_acc = 0.0
+    for epoch in range(1, args.epochs + 1):
+        train_loader.sampler.set_epoch(epoch)
+        train_loss, train_acc = train(
+            model,
+            epoch,
+            train_loader,
+            optimizer,
+            dataset.num_classes,
+            train_metric,
+            rank,
+        )
+        val_acc = test(
+            model,
+            epoch,
+            val_loader,
+            val_metric,
+            rank,
+            'val',
+        )
+        test_acc = test(
+            model,
+            epoch,
+            test_loader,
+            test_metric,
+            rank,
+            'test',
+        )
+        if best_val_acc < val_acc:
+            best_val_acc = val_acc
+            best_test_acc = test_acc
+        if rank == 0:
+            print(f"Train Loss: {train_loss:.4f}, "
+                  f"Train Acc: {train_acc:.4f}, "
+                  f"Val Acc: {val_acc:.4f}, "
+                  f"Test Acc: {test_acc:.4f}")
+
+        lr_scheduler.step()
+
+    if rank == 0:
+        print(f"Best Val Acc: {best_val_acc:.4f}, "
+              f"Best Test Acc: {best_test_acc:.4f}")
+
+    dist.destroy_process_group()
+    logging.info("Process group destroyed")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--dataset", type=str, default="california")
+    parser.add_argument("--channels", type=int, default=128)
+    parser.add_argument("--num_prompts", type=int, default=128)
+    parser.add_argument("--num_layers", type=int, default=6)
+    parser.add_argument("--batch_size", type=int, default=256)
+    parser.add_argument("--lr", type=float, default=0.001)
+    parser.add_argument("--epochs", type=int, default=200)
+    parser.add_argument("--seed", type=int, default=0)
+    parser.add_argument("--compile", action="store_true")
+    args = parser.parse_args()
+
+    os.environ['MASTER_ADDR'] = 'localhost'
+    os.environ['MASTER_PORT'] = '12355'
+
+    world_size = torch.cuda.device_count()
+    mp.spawn(run, args=(world_size, args), nprocs=world_size, join=True)

--- a/examples/trompt_multi_gpu.py
+++ b/examples/trompt_multi_gpu.py
@@ -136,6 +136,10 @@ def run(rank: int, world_size: int, args: argparse.Namespace) -> None:
         dataset[0.7:0.79],
         dataset[0.79:],
     )
+    # Note that the last batch of evaluation loops is dropped for now because
+    # drop_last=False will duplicate samples to fill the last batch, leading to
+    # the wrong evaluation metrics.
+    # https://github.com/pytorch/pytorch/issues/25162
     train_loader = DataLoader(
         train_dataset.tensor_frame,
         batch_size=args.batch_size,
@@ -150,8 +154,8 @@ def run(rank: int, world_size: int, args: argparse.Namespace) -> None:
         batch_size=args.batch_size,
         sampler=DistributedSampler(
             val_dataset,
-            shuffle=False,
-            drop_last=False,
+            shuffle=True,
+            drop_last=True,
         ),
     )
     test_loader = DataLoader(
@@ -159,8 +163,8 @@ def run(rank: int, world_size: int, args: argparse.Namespace) -> None:
         batch_size=args.batch_size,
         sampler=DistributedSampler(
             test_dataset,
-            shuffle=False,
-            drop_last=False,
+            shuffle=True,
+            drop_last=True,
         ),
     )
     model = Trompt(

--- a/test/nn/models/test_compile.py
+++ b/test/nn/models/test_compile.py
@@ -54,7 +54,7 @@ from torch_frame.testing import withPackage
             Trompt,
             dict(channels=8, num_prompts=2),
             None,
-            4,
+            3,
             id="Trompt",
         ),
         pytest.param(

--- a/test/nn/models/test_trompt.py
+++ b/test/nn/models/test_trompt.py
@@ -47,7 +47,5 @@ def test_trompt(batch_size, use_stype_encoder_dicts):
         stype_encoder_dicts=stype_encoder_dicts,
     )
     model.reset_parameters()
-    out = model.forward_stacked(tensor_frame)
-    assert out.shape == (batch_size, num_layers, out_channels)
     pred = model(tensor_frame)
-    assert pred.shape == (batch_size, out_channels)
+    assert pred.shape == (batch_size, num_layers, out_channels)

--- a/torch_frame/nn/models/trompt.py
+++ b/torch_frame/nn/models/trompt.py
@@ -122,7 +122,7 @@ class Trompt(Module):
             trompt_conv.reset_parameters()
         self.trompt_decoder.reset_parameters()
 
-    def forward_stacked(self, tf: TensorFrame) -> Tensor:
+    def forward(self, tf: TensorFrame) -> Tensor:
         r"""Transforming :class:`TensorFrame` object into a series of output
         predictions at each layer. Used during training to compute layer-wise
         loss.
@@ -152,6 +152,3 @@ class Trompt(Module):
         # [batch_size, num_layers, out_channels]
         stacked_out = torch.cat(outs, dim=1)
         return stacked_out
-
-    def forward(self, tf: TensorFrame) -> Tensor:
-        return self.forward_stacked(tf).mean(dim=1)


### PR DESCRIPTION
Adds an example for training a model on multiple GPUs.

#### Usage

```console
$ python examples/trompt_multi_gpu.py
```

#### Changes
To enable it, this PR modifies `Trompt` accordingly:
```diff
- out = Trompt(...).forward_stacked(tf)  # forward_stacked is removed
+ out = Trompt(...)(tf)
  assert out.size() == (batch_size, num_layers, num_channels)
```

#### Some highlights in the script
* Unlike `examples/trompt.py`, it computes training accuracy batch-wise instead of computing it at the end of each epoch to save time (although model parameters change over steps within each epoch).
* It reduces losses and metrics with `all_reduce` and `torchmetrics`'s API across all ranks at the end of each epoch.
* It avoids unnecessary device synchronisations within each epoch, e.g., by not calling `float(cuda_tensor)`, and by setting `repeat_interleave(..., output_size=...)`.
* ... (I'm happy to elaborate if anything in the script is unclear.)

#### Benchmark results from `--dataset jannis` on `g6.12xlarge` with four L4 GPUs

| | four GPUs | single GPU |
|-|-|-|
| time per training step | **0.725 seconds** | 0.741 seconds |
| time per training epoch | **29 seconds** | 117 seconds |
| test accuracy | 80.23 % | 80.29 % |