### PR TITLE
Fix documentation build

### DIFF
--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -1,5 +1,8 @@
 version: 2
 
+sphinx:
+   configuration: docs/source/conf.py
+
 build:
    os: ubuntu-22.04
    tools:


### PR DESCRIPTION
https://about.readthedocs.com/blog/2024/12/deprecate-config-files-without-sphinx-or-mkdocs-config/