### PR TITLE
Support Python 3.12 and Python 3.13

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -43,3 +43,12 @@ runs:
     - name: List installed packages
       run: pip list
       shell: bash
+
+    # TODO: Include catboost in Python 3.13 CI when catboost supports it:
+    # https://github.com/catboost/catboost/issues/2748
+    - name: Exclude catboost on Python 3.13 from pyproject.toml
+      if: ${{ inputs.python-version == '3.13' }}
+      run: |
+        sed -i '/    "catboost",/d' pyproject.toml
+        cat pyproject.toml
+      shell: bash

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -3,7 +3,7 @@ name: Testing
 on:  # yamllint disable-line rule:truthy
   push:
     branches:
-      - master
+      - master      - aki/py313
   pull_request:
 
 concurrency:
@@ -17,19 +17,25 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version:
-          - '3.9'
-          - '3.11'
-        torch-version:
-          - '1.13'
-          - '2.0'
-          - '2.1'
-          - '2.2'
-          - '2.3'
-          - '2.4'
-          - '2.5'
-          - '2.6'
-          - 'nightly'
+        include:
+          - { torch-version: '1.13', python-version: '3.9' }
+          - { torch-version: '1.13', python-version: '3.11' }
+          - { torch-version: '2.0', python-version: '3.9' }
+          - { torch-version: '2.0', python-version: '3.11' }
+          - { torch-version: '2.1', python-version: '3.9' }
+          - { torch-version: '2.1', python-version: '3.11' }
+          - { torch-version: '2.2', python-version: '3.9' }
+          - { torch-version: '2.2', python-version: '3.12' }
+          - { torch-version: '2.3', python-version: '3.9' }
+          - { torch-version: '2.3', python-version: '3.12' }
+          - { torch-version: '2.4', python-version: '3.9' }
+          - { torch-version: '2.4', python-version: '3.12' }
+          - { torch-version: '2.5', python-version: '3.9' }
+          - { torch-version: '2.5', python-version: '3.13' }
+          - { torch-version: '2.6', python-version: '3.9' }
+          - { torch-version: '2.6', python-version: '3.13' }
+          - { torch-version: 'nightly', python-version: '3.9' }
+          - { torch-version: 'nightly', python-version: '3.13' }
 
     steps:
       - name: Checkout repository

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
+- Added support for Python 3.12 and 3.13 ([#500](https://github.com/pyg-team/pytorch-frame/pull/500))
 - Added support for PyTorch 2.6 ([#494](https://github.com/pyg-team/pytorch-frame/pull/494))
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@
 ______________________________________________________________________
 
 [![arXiv][arxiv-image]][arxiv-url]
+[![PyPI - Python Version](https://img.shields.io/pypi/pyversions/pytorch-frame)](https://pypi.org/project/pytorch-frame/)
 [![PyPI Version][pypi-image]][pypi-url]
 [![Testing Status][testing-image]][testing-url]
 [![Docs Status][docs-image]][docs-url]
@@ -245,7 +246,7 @@ The benchmark script for Hugging Face text encoders is in this [file](https://gi
 
 ## Installation
 
-PyTorch Frame is available for Python 3.9 to Python 3.11.
+PyTorch Frame is available for Python 3.9 to Python 3.13.
 
 ```
 pip install pytorch-frame

--- a/docs/source/get_started/installation.rst
+++ b/docs/source/get_started/installation.rst
@@ -1,7 +1,7 @@
 Installation
 ============
 
-:pyf:`PyTorch Frame` is available for `Python 3.9` to `Python 3.11` on Linux, Windows and macOS.
+:pyf:`PyTorch Frame` is available for `Python 3.9` to `Python 3.13` on Linux, Windows and macOS.
 
 Installation via PyPI
 ---------------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,8 @@ classifiers=[
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Programming Language :: Python :: 3 :: Only",
 ]
 dependencies=[

--- a/test/gbdt/test_gbdt.py
+++ b/test/gbdt/test_gbdt.py
@@ -1,4 +1,5 @@
 import os.path as osp
+import sys
 import tempfile
 
 import pytest
@@ -13,7 +14,13 @@ from torch_frame.testing.text_embedder import HashTextEmbedder
 
 
 @pytest.mark.parametrize('gbdt_cls', [
-    CatBoost,
+    pytest.param(
+        CatBoost,
+        marks=pytest.mark.skipif(
+            sys.version_info >= (3, 13),
+            reason="Not supported on Python 3.13",
+        ),
+    ),
     XGBoost,
     LightGBM,
 ])

--- a/test/nn/models/test_compile.py
+++ b/test/nn/models/test_compile.py
@@ -14,7 +14,7 @@ from torch_frame.nn.models import (
 from torch_frame.testing import withPackage
 
 
-@withPackage("torch>=2.5.0")
+@withPackage("torch>=2.6.0")
 @pytest.mark.parametrize(
     "model_cls, model_kwargs, stypes, expected_graph_breaks",
     [


### PR DESCRIPTION
* Adds support for Python 3.12 and Python 3.13.
* Disables tests that use `catboost` as they don't support Python 3.13 yet as reported in https://github.com/catboost/catboost/issues/2748.
* Bumps the PyTorch version required for `torch.compile` tests as PyTorch 2.6 is the first version that supports `torch.compile` with Python 3.13.