### PR TITLE
lint: switch `pyupgrade` to Ruff's rule UP

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -33,13 +33,6 @@ repos:
         name: Lint yaml
         args: [-d, '{extends: default, rules: {line-length: disable, document-start: disable, truthy: {level: error}, braces: {max-spaces-inside: 1}}}']
 
-  - repo: https://github.com/asottile/pyupgrade
-    rev: v3.19.1
-    hooks:
-      - id: pyupgrade
-        name: Upgrade Python syntax
-        args: [--py39-plus]
-
   - repo: https://github.com/PyCQA/autoflake
     rev: v2.3.1
     hooks:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 
+- Lint: switch `pyupgrade` to Ruff's rule `UP` ([#499](https://github.com/pyg-team/pytorch-frame/pull/499))
+
 ### Deprecated
 
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,6 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 
-- Lint: switch `pyupgrade` to Ruff's rule `UP` ([#499](https://github.com/pyg-team/pytorch-frame/pull/499))
-
 ### Deprecated
 
 ### Removed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,8 +69,10 @@ changelog="https://github.com/pyg-team/pytorch-frame/blob/master/CHANGELOG.md"
 name="torch_frame"
 
 [tool.ruff]  # https://docs.astral.sh/ruff/rules
+target-version = "py39"
 select = [
     "D",  # pydocstyle
+    "UP", # pyupgrade
 ]
 ignore = [
     "D100",  # TODO: Don't ignore "Missing docstring in public module"
@@ -84,7 +86,6 @@ ignore = [
 src = ["torch_frame"]
 line-length = 80
 indent-width = 4
-target-version = "py39"
 
 # [tool.ruff.per-files-ignores]
 


### PR DESCRIPTION
since Ruff is already introduce it would simplify and speed-up linting