### PR TITLE
Support CatBoost in Python 3.13

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -43,12 +43,3 @@ runs:
     - name: List installed packages
       run: pip list
       shell: bash
-
-    # TODO: Include catboost in Python 3.13 CI when catboost supports it:
-    # https://github.com/catboost/catboost/issues/2748
-    - name: Exclude catboost on Python 3.13 from pyproject.toml
-      if: ${{ inputs.python-version == '3.13' }}
-      run: |
-        sed -i '/    "catboost",/d' pyproject.toml
-        cat pyproject.toml
-      shell: bash

--- a/test/gbdt/test_gbdt.py
+++ b/test/gbdt/test_gbdt.py
@@ -1,5 +1,4 @@
 import os.path as osp
-import sys
 import tempfile
 
 import pytest

--- a/test/gbdt/test_gbdt.py
+++ b/test/gbdt/test_gbdt.py
@@ -13,21 +13,11 @@ from torch_frame.gbdt import CatBoost, LightGBM, XGBoost
 from torch_frame.testing.text_embedder import HashTextEmbedder
 
 
-@pytest.mark.parametrize(
-    'gbdt_cls',
-    [
-        # TODO: Run CatBoost test on Python 3.13 once supported
-        # https://github.com/catboost/catboost/issues/2748
-        pytest.param(
-            CatBoost,
-            marks=pytest.mark.skipif(
-                sys.version_info >= (3, 13),
-                reason="Not supported on Python 3.13",
-            ),
-        ),
-        XGBoost,
-        LightGBM,
-    ])
+@pytest.mark.parametrize('gbdt_cls', [
+    CatBoost,
+    XGBoost,
+    LightGBM,
+])
 @pytest.mark.parametrize('stypes', [
     [stype.numerical],
     [stype.categorical],


### PR DESCRIPTION
https://github.com/catboost/catboost/releases/tag/v1.2.8 started supporting Python 3.13 via https://github.com/catboost/catboost/issues/2748.