### PR TITLE
Fix NumPy and PyTorch incompatibility error in CI

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -24,7 +24,7 @@ runs:
         cache-dependency-path: |
           pyproject.toml
 
-    - name: Downgrade NumPy if necessary
+    - name: Pre-install NumPy<2 if necessary
       run: |
         [[ ${{ inputs.torch-version }} =~ ^2\.[0-2] ]] && pip install 'numpy<2'
       shell: bash

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -26,7 +26,7 @@ runs:
 
     - name: Pre-install NumPy<2 if necessary
       run: |
-        [[ ${{ inputs.torch-version }} =~ ^2\.[0-2] ]] && pip install 'numpy<2'
+        [[ ${{ inputs.torch-version }} =~ ^2\.[0-2] ]] && pip install 'numpy<2' || echo "Skipping NumPy<2 installation"
       shell: bash
 
     - name: Install PyTorch ${{ inputs.torch-version }}+${{ inputs.cuda-version }}

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -24,24 +24,28 @@ runs:
         cache-dependency-path: |
           pyproject.toml
 
+    - name: Downgrade NumPy if necessary
+      run: |
+        [[ ${{ inputs.torch-version }} =~ ^2\.[0-2] ]] && pip install 'numpy<2'
+      shell: bash
+
     - name: Install PyTorch ${{ inputs.torch-version }}+${{ inputs.cuda-version }}
       if: ${{ inputs.torch-version != 'nightly' }}
       run: |
         pip install torch==${{ inputs.torch-version }}.* --extra-index-url https://download.pytorch.org/whl/${{ inputs.cuda-version }}
-        python -c "import torch; print('PyTorch:', torch.__version__)"
-        python -c "import torch; print('CUDA:', torch.version.cuda)"
       shell: bash
 
     - name: Install PyTorch ${{ inputs.torch-version }}+${{ inputs.cuda-version }}
       if: ${{ inputs.torch-version == 'nightly' }}
       run: |
         pip install --pre torch --extra-index-url https://download.pytorch.org/whl/nightly/${{ inputs.cuda-version }}
-        python -c "import torch; print('PyTorch:', torch.__version__)"
-        python -c "import torch; print('CUDA:', torch.version.cuda)"
       shell: bash
 
     - name: List installed packages
-      run: pip list
+      run: |
+        pip list
+        python -c "import torch; print('PyTorch:', torch.__version__)"
+        python -c "import torch; print('CUDA:', torch.version.cuda)"
       shell: bash
 
     # TODO: Include catboost in Python 3.13 CI when catboost supports it:


### PR DESCRIPTION
Fixes:

```
A module that was compiled using NumPy 1.x cannot be run in
NumPy 2.0.2 as it may crash. To support both 1.x and 2.x
versions of NumPy, modules must be compiled with NumPy 2.0.
Some module may need to rebuild instead e.g. with 'pybind11>=2.12'.
If you are a user of the module, the easiest solution will be to
downgrade to 'numpy<2' or try to upgrade the affected module.
We expect that some modules will need time to support NumPy 2.
```