### PR TITLE
Migrate to modern logger interface

### DIFF
--- a/torch_frame/utils/infer_stype.py
+++ b/torch_frame/utils/infer_stype.py
@@ -154,7 +154,7 @@ def infer_series_stype(ser: Series) -> stype | None:
                                           MultiCategoricalTensorMapper.
                                           split_by_sep(row, sep)).explode()))
                     except Exception as e:
-                        logging.warn(
+                        logging.warning(
                             "Mapping series into multicategorical stype "
                             f"with separator {sep} raised an exception {e}")
                         continue


### PR DESCRIPTION
## PR Summary
The `logger.warn()` method is deprecated since Python2.7 and replaced with `logger.warning()`. It leads to those warnings:
```python
DeprecationWarning: The 'warn' method is deprecated, use 'warning' instead
```
