### PR TITLE
Add support for `pandas>=3.0.0`

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -20,7 +20,6 @@ jobs:
         include:
           - {torch-version: '2.7', python-version: '3.10', pandas-pin: '==1.*', numpy-pin: '==1.*'}
           - {torch-version: '2.7', python-version: '3.10', pandas-pin: '>=2.2,<3'}
-          - {torch-version: '2.7', python-version: '3.13', pandas-pin: '==3.*'}
           - {torch-version: '2.7', python-version: '3.10'}
           - {torch-version: '2.7', python-version: '3.13'}
           - {torch-version: '2.11', python-version: '3.10'}

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -20,7 +20,7 @@ jobs:
         include:
           - {torch-version: '2.7', python-version: '3.10', pandas-pin: '==1.*', numpy-pin: '==1.*'}
           - {torch-version: '2.7', python-version: '3.10', pandas-pin: '>=2.2,<3'}
-          - {torch-version: '2.7', python-version: '3.10', pandas-pin: '==3.*'}
+          - {torch-version: '2.7', python-version: '3.13', pandas-pin: '==3.*'}
           - {torch-version: '2.7', python-version: '3.10'}
           - {torch-version: '2.7', python-version: '3.13'}
           - {torch-version: '2.11', python-version: '3.10'}

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -18,7 +18,9 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - {torch-version: '2.7', python-version: '3.10', pandas-version: '1'}
+          - {torch-version: '2.7', python-version: '3.10', pandas-pin: '==1.*', numpy-pin: '==1.*'}
+          - {torch-version: '2.7', python-version: '3.10', pandas-pin: '>=2.2,<3'}
+          - {torch-version: '2.7', python-version: '3.10', pandas-pin: '==3.*'}
           - {torch-version: '2.7', python-version: '3.10'}
           - {torch-version: '2.7', python-version: '3.13'}
           - {torch-version: '2.11', python-version: '3.10'}
@@ -63,10 +65,14 @@ jobs:
           pip install -e .[full,test]
           pip list
 
-      - name: Pin pandas to ${{ matrix.pandas-version }}.*
-        if: ${{ matrix.pandas-version && steps.changed-files-specific.outputs.only_changed != 'true' }}
+      - name: Pin pandas/numpy
+        if: ${{ matrix.pandas-pin && steps.changed-files-specific.outputs.only_changed != 'true' }}
         run: |
-          pip install "pandas==${{ matrix.pandas-version }}.*"
+          pkgs=("pandas${{ matrix.pandas-pin }}")
+          if [ -n "${{ matrix.numpy-pin }}" ]; then
+            pkgs+=("numpy${{ matrix.numpy-pin }}")
+          fi
+          pip install "${pkgs[@]}"
           pip list
 
       - name: Run tests

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -18,6 +18,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          - {torch-version: '2.7', python-version: '3.10', pandas-version: '1'}
           - {torch-version: '2.7', python-version: '3.10'}
           - {torch-version: '2.7', python-version: '3.13'}
           - {torch-version: '2.11', python-version: '3.10'}
@@ -60,6 +61,12 @@ jobs:
         if: steps.changed-files-specific.outputs.only_changed != 'true'
         run: |
           pip install -e .[full,test]
+          pip list
+
+      - name: Pin pandas to ${{ matrix.pandas-version }}.*
+        if: ${{ matrix.pandas-version && steps.changed-files-specific.outputs.only_changed != 'true' }}
+        run: |
+          pip install "pandas==${{ matrix.pandas-version }}.*"
           pip list
 
       - name: Run tests

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- Fixed pandas 3.0 compatibility in `MultiCategoricalTensorMapper`, `TextTokenizationTensorMapper`, and `EmbeddingTensorMapper` ([#602](https://github.com/pyg-team/pytorch-frame/pull/602))
+
 ### Security
 
 ## [0.3.0] - 2025-11-02

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ classifiers=[
 ]
 dependencies=[
     "numpy",
-    "pandas<3.0.0",
+    "pandas",
     "torch",
     "tqdm",
     "pyarrow",

--- a/torch_frame/data/mapper.py
+++ b/torch_frame/data/mapper.py
@@ -12,7 +12,7 @@ from tqdm import tqdm
 
 from torch_frame.data.multi_embedding_tensor import MultiEmbeddingTensor
 from torch_frame.data.multi_nested_tensor import MultiNestedTensor
-from torch_frame.typing import Series, TensorData, TextTokenizationOutputs
+from torch_frame.typing import WITH_PD3, Series, TensorData, TextTokenizationOutputs
 
 NUM_MONTHS_PER_YEAR = 12
 '''
@@ -325,7 +325,10 @@ class TextTokenizationTensorMapper(TensorMapper):
         *,
         device: torch.device | None = None,
     ) -> dict[str, MultiNestedTensor]:
-        ser_list = [str(x) for x in ser]
+        if WITH_PD3:
+            ser_list = [str(x) for x in ser]
+        else:
+            ser_list = ser.astype(str).tolist()
 
         feat_dict = {}
         if self.batch_size is None:
@@ -414,7 +417,10 @@ class EmbeddingTensorMapper(TensorMapper):
     ) -> MultiEmbeddingTensor:
 
         if self.embedder is not None:
-            ser_list = [str(x) for x in ser]
+            if WITH_PD3:
+                ser_list = [str(x) for x in ser]
+            else:
+                ser_list = ser.astype(str).tolist()
             if self.batch_size is None:
                 values = self.embedder(ser_list)
             else:

--- a/torch_frame/data/mapper.py
+++ b/torch_frame/data/mapper.py
@@ -144,7 +144,7 @@ class MultiCategoricalTensorMapper(TensorMapper):
 
     @staticmethod
     def split_by_sep(row: str | Iterable | None, sep: None | str) -> set[Any]:
-        if row is None or row is np.nan:
+        if row is None or row is np.nan or row is pd.NA:
             return {-1}
         elif isinstance(row, str):
             assert sep is not None
@@ -166,7 +166,7 @@ class MultiCategoricalTensorMapper(TensorMapper):
         *,
         device: torch.device | None = None,
     ) -> MultiNestedTensor:
-        if ser.dtype != 'object':
+        if ser.dtype != 'object' and not pd.api.types.is_string_dtype(ser):
             raise ValueError('Multi-categorical types expect string as input')
         values = []
         original_index = ser.index

--- a/torch_frame/data/mapper.py
+++ b/torch_frame/data/mapper.py
@@ -325,8 +325,7 @@ class TextTokenizationTensorMapper(TensorMapper):
         *,
         device: torch.device | None = None,
     ) -> dict[str, MultiNestedTensor]:
-        ser = ser.astype(str)
-        ser_list = ser.tolist()
+        ser_list = [str(x) for x in ser]
 
         feat_dict = {}
         if self.batch_size is None:
@@ -415,8 +414,7 @@ class EmbeddingTensorMapper(TensorMapper):
     ) -> MultiEmbeddingTensor:
 
         if self.embedder is not None:
-            ser = ser.astype(str)
-            ser_list = ser.tolist()
+            ser_list = [str(x) for x in ser]
             if self.batch_size is None:
                 values = self.embedder(ser_list)
             else:

--- a/torch_frame/data/mapper.py
+++ b/torch_frame/data/mapper.py
@@ -12,7 +12,12 @@ from tqdm import tqdm
 
 from torch_frame.data.multi_embedding_tensor import MultiEmbeddingTensor
 from torch_frame.data.multi_nested_tensor import MultiNestedTensor
-from torch_frame.typing import WITH_PD3, Series, TensorData, TextTokenizationOutputs
+from torch_frame.typing import (
+    WITH_PD3,
+    Series,
+    TensorData,
+    TextTokenizationOutputs,
+)
 
 NUM_MONTHS_PER_YEAR = 12
 '''

--- a/torch_frame/typing.py
+++ b/torch_frame/typing.py
@@ -14,6 +14,8 @@ from torch_frame.data.multi_nested_tensor import MultiNestedTensor
 WITH_PT20 = int(torch.__version__.split('.')[0]) >= 2
 WITH_PT24 = WITH_PT20 and int(torch.__version__.split('.')[1]) >= 4
 
+WITH_PD3 = int(pd.__version__.split('.')[0]) >= 3
+
 
 class Metric(Enum):
     r"""The metric.

--- a/torch_frame/typing.py
+++ b/torch_frame/typing.py
@@ -15,6 +15,7 @@ WITH_PT20 = int(torch.__version__.split('.')[0]) >= 2
 WITH_PT24 = WITH_PT20 and int(torch.__version__.split('.')[1]) >= 4
 WITH_PD3 = int(pd.__version__.split('.')[0]) >= 3
 
+
 class Metric(Enum):
     r"""The metric.
 

--- a/torch_frame/typing.py
+++ b/torch_frame/typing.py
@@ -13,9 +13,7 @@ from torch_frame.data.multi_nested_tensor import MultiNestedTensor
 
 WITH_PT20 = int(torch.__version__.split('.')[0]) >= 2
 WITH_PT24 = WITH_PT20 and int(torch.__version__.split('.')[1]) >= 4
-
 WITH_PD3 = int(pd.__version__.split('.')[0]) >= 3
-
 
 class Metric(Enum):
     r"""The metric.


### PR DESCRIPTION
* Remove the `pandas<3.0.0` pin in `pyproject.toml`
* Fix `MultiCategoricalTensorMapper` in `torch_frame/data/mapper.py` to support pandas 3.0, which uses `StringDtype` instead of `object` for string columns and `pd.NA` instead of `np.nan` for missing values (pandas-dev/pandas#54792)

