### PR TITLE
CI: Skip dataset tests in PR CI

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -78,7 +78,8 @@ jobs:
       - name: Run tests
         if: steps.changed-files-specific.outputs.only_changed != 'true'
         run: |
-          pytest --cov --cov-report=xml
+          pytest --cov --cov-report=xml \
+            ${{ github.event_name == 'pull_request' && '--ignore=test/datasets' || '' }}
 
       - name: Upload coverage
         if: steps.changed-files-specific.outputs.only_changed != 'true'


### PR DESCRIPTION
## Summary

- Skip test/datasets during pull request CI pytest runs.
- Keep dataset tests enabled for non-PR workflow runs, including push to master and manual dispatch.

## Why

Dataset tests such as test/datasets/test_movielens_1m.py materialize real datasets and should not run as part of PR CI. Skipping the full test/datasets directory also covers the other dataset-focused pytest modules.

## Validation

- git diff --check
- PR CI passed for changelog, docs, mypy, pre-commit, Read the Docs, and the full pytest matrix.
- Attempted local pytest --collect-only --ignore=test/datasets, but local pytest is not installed in this checkout.